### PR TITLE
Make sure signRequest is called before send

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -215,6 +215,10 @@ function rawRequest(opts, cb) {
         req.emit('upgradeResult', (err || null), res, socket, _head);
     });
 
+    if (opts.signRequest) {
+        opts.signRequest(req);
+    }
+
     req.once('socket', function onSocket(socket) {
         var _socket = socket;
 
@@ -259,10 +263,6 @@ function rawRequest(opts, cb) {
             cb(null, req);
         });
     });
-
-    if (opts.signRequest) {
-        opts.signRequest(req);
-    }
 
     if (log.trace()) {
         log.trace({client_req: opts}, 'request sent');

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "jscs": "^1.13.1",
     "mkdirp": "^0.5.1",
     "mocha": "^2.2.5",
+    "nock": "^2.10.0",
     "restify": "git+https://git@github.com/restify/node-restify.git#master"
   },
   "dependencies": {

--- a/test/nock.js
+++ b/test/nock.js
@@ -1,0 +1,49 @@
+// Copyright 2012 Mark Cavage <mcavage@gmail.com> All rights reserved.
+/* eslint-disable no-console, no-undefined */
+// jscs:disable maximumLineLength
+
+'use strict';
+
+var assert = require('chai').assert;
+var nock;
+var clients = require('../lib');
+
+///--- Globals
+
+var PORT = process.env.UNIT_TEST_PORT || 0;
+
+///--- Tests
+
+describe('restify-client tests against nock', function () {
+    before(function () {
+      // Lazy initialization of nock, as it otherwise interferes with the regular tests
+      nock = require('nock');
+    });
+
+    after(function () {
+      nock.restore();
+    });
+
+    it('sign the request made against nock', function (done) {
+        var signFunction = function (request) {
+          request.setHeader('X-Awesome-Signature', 'ken sent me');
+        };
+
+        var nockContext = nock('http://127.0.0.1', {allowUnmocked: true})
+            .filteringRequestBody(/.*/, '*')
+            .get('/nock')
+            .reply(200, function (uri, requestBody) {
+              assert.equal(this.req.headers['x-awesome-signature'], 'ken sent me',
+                          'signature header was missing from the request');
+            });
+
+        var client = clients.createJsonClient({
+            url: 'http://127.0.0.1',
+            signRequest: signFunction
+        });
+
+        client.get('/nock', done);
+    });
+
+});
+


### PR DESCRIPTION
If the socket connected very quickly (e.g. to localhost), the
signRequest callback was never called.
