### PR TITLE
Update dtrace provider and other out of date deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "coveralls": "^2.11.2",
-    "eslint": "^0.24.0",
+    "eslint": "^1.3.1",
     "istanbul": "^0.3.15",
-    "jscs": "^1.13.1",
+    "jscs": "^2.1.1",
     "mkdirp": "^0.5.1",
     "mocha": "^2.2.5",
     "nock": "^2.10.0",
@@ -56,7 +56,7 @@
     "assert-plus": "^0.1.5",
     "backoff": "^2.4.1",
     "bunyan": "^1.4.0",
-    "dtrace-provider": "^0.5.0",
+    "dtrace-provider": "^0.6.0",
     "keep-alive-agent": "0.0.1",
     "lodash": "^3.9.3",
     "lru-cache": "^2.6.4",
@@ -64,7 +64,7 @@
     "node-uuid": "^1.4.3",
     "once": "^1.3.2",
     "restify-errors": "git+https://git@github.com/restify/errors.git#master",
-    "semver": "^4.3.6",
+    "semver": "^5.0.1",
     "tunnel-agent": "^0.4.0"
   }
 }


### PR DESCRIPTION
#### Normal Deps
Dep | Old Version | New Version
-------- | --------- | -----------
dtrace-provider |   ^0.5.0 |  ^0.6.0
semver | ^4.3.6 |  ^5.0.1

#### Dev Deps
Dep | Old Version | New Version
-------- | --------- | -----------
 eslint | ^0.24.0 | ^1.3.1
 jscs | ^1.13.1 | ^2.1.1