### PR TITLE
Adding support to Req/Res Auditor similar to Server.

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -19,6 +19,7 @@ var once = require('once');
 var tunnelAgent = require('tunnel-agent');
 
 var dtrace = require('./helpers/dtrace');
+var auditor = require('./helpers/auditor');
 var errors = require('restify-errors');
 var serializers = require('./helpers/bunyan').serializers;
 
@@ -152,9 +153,22 @@ function rawRequest(opts, cb) {
 
     var emitResult = once(function _emitResult(_err, _req, _res) {
         _req.emit('result', _err, _res);
+
+        // Use the default auditor with the switch "opts.audit: true | false"
+        if (opts.audit.defaultEnabled) {
+            auditor(_err, _req, _res);
+
+        } else if (opts.audit.func && typeof opts.audit.func === 'function') {
+            // Use the function provided by the user through "opts.auditor"
+            opts.audit.func(_err, _req, _res);
+        }
     });
 
+    var requestTime = new Date().getTime();
     req = proto.request(opts, function onResponse(res) {
+        var latency = Date.now() - requestTime;
+        res.headers['x-request-received'] = requestTime;
+        res.headers['x-request-processing-time'] = latency;
         clearTimeout(connectionTimer);
         clearTimeout(requestTimer);
 
@@ -343,6 +357,11 @@ function HttpClient(options) {
     this.requestTimeout = options.requestTimeout || false;
     this.headers = options.headers || {};
     this.log = options.log;
+    this.audit = {
+        func: options.auditor || undefined,
+        defaultEnabled: options.audit || false
+    };
+
 
     if (!this.log.serializers) {
         // Ensure logger has a reasonable serializer for `client_res`
@@ -569,6 +588,8 @@ HttpClient.prototype.request = function request(opts, cb) {
     /* eslint-disable no-param-reassign */
     cb = once(cb);
     /* eslint-enable no-param-reassign */
+
+    opts.audit = this.audit;
 
     if (opts.retry === false) {
         rawRequest(opts, cb);

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -358,7 +358,7 @@ function HttpClient(options) {
     this.headers = options.headers || {};
     this.log = options.log;
     this.audit = {
-        func: options.auditor || undefined,
+        func: options.auditor || null,
         defaultEnabled: options.audit || false
     };
 

--- a/lib/helpers/auditor.js
+++ b/lib/helpers/auditor.js
@@ -9,6 +9,8 @@ module.exports = audit;
  * @param  {Object} err   The http error object.
  * @param  {Object} req   The http request object.
  * @param  {Object} res   The http response object.
+ *
+ * @returns {undefined} Does not return anything.
  */
 function audit(err, req, res) {
     req.headers = req._headers;
@@ -30,10 +32,11 @@ function audit(err, req, res) {
     // Log the request/response properly with the function
     // associated with the response status code
     logFn.call(log, obj);
-};
+}
 
 /**
- * @return {string} status The level of the logger depending on the HTTP.
+ * @param {String} status from the web server.
+ * @returns {String} The level of the logger depending on the HTTP.
  */
 function _defaultLevelFn(status) {
     if (status >= 500) { // server internal error or error

--- a/lib/helpers/auditor.js
+++ b/lib/helpers/auditor.js
@@ -26,24 +26,5 @@ function audit(err, req, res) {
         secure: req.secure
     };
 
-    var level = _defaultLevelFn(res ? res.statusCode : 200);
-    var logFn = log[level] ? log[level] : log.info;
-
-    // Log the request/response properly with the function
-    // associated with the response status code
-    logFn.call(log, obj);
-}
-
-/**
- * @param {String} status from the web server.
- * @returns {String} The level of the logger depending on the HTTP.
- */
-function _defaultLevelFn(status) {
-    if (status >= 500) { // server internal error or error
-        return 'error';
-
-    } else if (status >= 400) { // client error
-        return 'warn';
-    }
-    return 'info';
+    log.info(obj);
 }

--- a/lib/helpers/auditor.js
+++ b/lib/helpers/auditor.js
@@ -26,7 +26,7 @@ function audit(err, req, res) {
         secure: req.secure
     };
 
-    var level = _defaultLevelFn(res.statusCode);
+    var level = _defaultLevelFn(res ? res.statusCode : 200);
     var logFn = log[level] ? log[level] : log.info;
 
     // Log the request/response properly with the function

--- a/lib/helpers/auditor.js
+++ b/lib/helpers/auditor.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports = audit;
+
+/**
+ * Audits the req/res for the client. The audit will use bunyan's
+ * formatters. See bunyan-format for the user-friendly output.
+ *
+ * @param  {Object} err   The http error object.
+ * @param  {Object} req   The http request object.
+ * @param  {Object} res   The http response object.
+ */
+function audit(err, req, res) {
+    req.headers = req._headers;
+    req.url = req.path;
+    var log = req.log;
+
+    var obj = {
+        remoteAddress: req.connection.remoteAddress,
+        remotePort: req.connection.remotePort,
+        req: req,
+        res: res,
+        err: err,
+        secure: req.secure
+    };
+
+    var level = _defaultLevelFn(res.statusCode);
+    var logFn = log[level] ? log[level] : log.info;
+
+    // Log the request/response properly with the function
+    // associated with the response status code
+    logFn.call(log, obj);
+};
+
+/**
+ * @return {string} status The level of the logger depending on the HTTP.
+ */
+function _defaultLevelFn(status) {
+    if (status >= 500) { // server internal error or error
+        return 'error';
+
+    } else if (status >= 400) { // client error
+        return 'warn';
+    }
+    return 'info';
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-clients",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "lib/index.js",
   "description": "HttpClient, StringClient, and JsonClient extracted from restify",
   "homepage": "http://www.restify.com",


### PR DESCRIPTION
This is the initial support for the Req/Res auditor. The user must
provide the following options and can fix #14.

* opts.audit: true | false
- This enables the default implementation provided at
  lib/helpers/auditor.js

* opts.auditor: function
- This enables the user to provide his/her own auditor function.

This was heavily inspired by the node-restify's auditor plugin.

*	modified:   lib/HttpClient.js
- Requiring the new auditor
- Calling the default auditor function if the property "audit" is
  provided (progagated as opts.audit.defaultEnabled)
- Calling the user-provided function (propagated as opts.audit.func).
- Adding the latency information header that is commonly used by the
  community.
- Adding the "audit" property to the class, with the possible user's
  options.
- Propagating the audit property before the rawRequest is executed.

*	new file:   lib/helpers/auditor.js
- The auditor helper inspired by node-restify's audit plugin.
- Properly logging the outout depending on the http status code.