### PR TITLE
Fix incorrect client websocket example

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ connection with a server.  For example, using the
       }
     };
     client.get(options, function(err, res, socket, head) {
-      req.once('upgradeResult', function(err, res, socket, head) {
-        var shed = ws.connect(res, socket, head, wskey);
+      res.once('upgradeResult', function(err2, res2, socket2, head2) {
+        var shed = ws.connect(res2, socket2, head2, wskey);
         shed.on('text', function(msg) {
           console.log('message from server: ' + msg);
           shed.end();


### PR DESCRIPTION
The documentation was using a `req` variable that is not declared. Additionally the second anonymous function definition hides the `err`, `res`, `socket`, and `head` variables.

This matches my eariler PR for the restify/node-restify repo https://github.com/restify/node-restify/pull/960