### PR TITLE
Follow redirects

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -366,6 +366,8 @@ function HttpClient(options) {
     assert.optionalFunc(options.signRequest, 'options.signRequest');
     assert.optionalString(options.socketPath, 'options.socketPath');
     assert.optionalString(options.url, 'options.url');
+    assert.optionalBool(options.followRedirects, 'options.followRedirects');
+    assert.optionalNumber(options.maxRedirects, 'options.maxRedirects');
 
     EventEmitter.call(this);
 

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -51,6 +51,8 @@ if (!nativeKeepAlive) {
 var VERSION = JSON.parse(fs.readFileSync(path.join(__dirname, './../package.json'), 'utf8')).version;
 // jscs:enable maximumLineLength
 
+var REDIRECT_CODES = [301, 302, 303, 307];
+
 ///--- Helpers
 
 function cloneRetryOptions(options, defaults) {
@@ -105,6 +107,16 @@ function RequestTimeoutError(ms) {
 }
 util.inherits(RequestTimeoutError, Error);
 
+function TooManyRedirectsError(redirectNumber) {
+    if (Error.captureStackTrace) {
+        Error.captureStackTrace(this, TooManyRedirectsError);
+    }
+
+    this.message = 'Aborted after ' + redirectNumber + ' redirects';
+    this.name = 'TooManyRedirectsError';
+}
+util.inherits(TooManyRedirectsError, Error);
+
 function rawRequest(opts, cb) {
     assert.object(opts, 'options');
     assert.object(opts.log, 'options.log');
@@ -150,8 +162,32 @@ function rawRequest(opts, cb) {
         ]);
     });
 
+    var handleRedirect = function (_err, _req, _res) {
+        if (_err ||
+            !opts.followRedirects ||
+            REDIRECT_CODES.indexOf(_res.statusCode) < 0) {
+            return false;
+        }
+
+        if (opts.maxRedirects &&
+            opts.redirects >= opts.maxRedirects) {
+            var err = new TooManyRedirectsError(opts.redirects);
+            _req.emit('result', err, _res);
+        } else {
+            opts.redirects = (opts.redirects || 0) + 1;
+            _res.forceGet = _res.statusCode !== 307 && _req.method !== 'HEAD';
+            _req.emit('redirect', _res);
+        }
+
+        return true;
+    };
+
     var emitResult = once(function _emitResult(_err, _req, _res) {
-        _req.emit('result', _err, _res);
+        var redirected = handleRedirect(_err, _req, _res);
+
+        if (!redirected) {
+            _req.emit('result', _err, _res);
+        }
     });
 
     req = proto.request(opts, function onResponse(res) {
@@ -343,6 +379,8 @@ function HttpClient(options) {
     this.requestTimeout = options.requestTimeout || false;
     this.headers = options.headers || {};
     this.log = options.log;
+    this.followRedirects = options.followRedirects || false;
+    this.maxRedirects = options.maxRedirects || 5;
 
     if (!this.log.serializers) {
         // Ensure logger has a reasonable serializer for `client_res`
@@ -632,6 +670,14 @@ HttpClient.prototype._options = function (method, options) {
 
     if (this.socketPath) {
         opts.socketPath = this.socketPath;
+    }
+
+    if (this.followRedirects) {
+        opts.followRedirects = this.followRedirects;
+    }
+
+    if (this.maxRedirects) {
+        opts.maxRedirects = this.maxRedirects;
     }
 
     Object.keys(this.url).forEach(function (k) {

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -86,6 +86,7 @@ function defaultUserAgent() {
     return (UA);
 }
 
+errors.makeConstructor('TooManyRedirectsError');
 
 function ConnectTimeoutError(ms) {
     if (Error.captureStackTrace) {
@@ -106,16 +107,6 @@ function RequestTimeoutError(ms) {
     this.name = 'RequestTimeoutError';
 }
 util.inherits(RequestTimeoutError, Error);
-
-function TooManyRedirectsError(redirectNumber) {
-    if (Error.captureStackTrace) {
-        Error.captureStackTrace(this, TooManyRedirectsError);
-    }
-
-    this.message = 'Aborted after ' + redirectNumber + ' redirects';
-    this.name = 'TooManyRedirectsError';
-}
-util.inherits(TooManyRedirectsError, Error);
 
 function rawRequest(opts, cb) {
     assert.object(opts, 'options');
@@ -171,7 +162,8 @@ function rawRequest(opts, cb) {
 
         if (opts.maxRedirects &&
             opts.redirects >= opts.maxRedirects) {
-            var err = new TooManyRedirectsError(opts.redirects);
+            var msg = 'Aborted after %s redirects';
+            var err = new errors.TooManyRedirectsError(msg, opts.redirects);
             _req.emit('result', err, _res);
         } else {
             opts.redirects = (opts.redirects || 0) + 1;

--- a/lib/StringClient.js
+++ b/lib/StringClient.js
@@ -96,6 +96,7 @@ StringClient.prototype.read = function read(options, callback) {
 
         req.once('result', self.parse(req, callback));
         req.once('redirect', function (res) {
+            res.resume();
             options.path = res.headers.location;
 
             if (res.forceGet) {
@@ -135,6 +136,7 @@ StringClient.prototype.write = function write(options, body, callback) {
 
             req.once('result', self.parse(req, callback));
             req.once('redirect', function (res) {
+                res.resume();
                 options.path = res.headers.location;
 
                 if (res.forceGet) {

--- a/lib/StringClient.js
+++ b/lib/StringClient.js
@@ -81,6 +81,12 @@ StringClient.prototype.patch = function patch(options, body, callback) {
 };
 
 
+var forceGetOptions = function (options) {
+    options.method = 'GET';
+    delete options.headers['content-length'];
+};
+
+
 StringClient.prototype.read = function read(options, callback) {
     var self = this;
     this.request(options, function _parse(err, req) {
@@ -89,6 +95,14 @@ StringClient.prototype.read = function read(options, callback) {
         }
 
         req.once('result', self.parse(req, callback));
+        req.once('redirect', function (res) {
+            options.path = res.headers.location;
+
+            if (res.forceGet) {
+                forceGetOptions(options);
+            }
+            self.read(options, callback);
+        });
         return (req.end());
     });
     return (this);
@@ -99,6 +113,7 @@ StringClient.prototype.write = function write(options, body, callback) {
 
     var self = this;
     var normalizedBody = body;
+    var proto = StringClient.prototype;
 
     if (normalizedBody !== null && typeof (normalizedBody) !== 'string') {
         normalizedBody = qs.stringify(normalizedBody);
@@ -119,6 +134,16 @@ StringClient.prototype.write = function write(options, body, callback) {
             }
 
             req.once('result', self.parse(req, callback));
+            req.once('redirect', function (res) {
+                options.path = res.headers.location;
+
+                if (res.forceGet) {
+                    forceGetOptions(options);
+                    proto.read.call(self, options, callback);
+                } else {
+                    proto.write.call(self, options, body, callback);
+                }
+            });
             req.end(data);
         });
     }

--- a/test/index.js
+++ b/test/index.js
@@ -53,7 +53,7 @@ function sendText(req, res, next) {
 }
 
 function sendRedirect(req, res, next) {
-    var statusCode = parseInt(req.params.status_code);
+    var statusCode = parseInt(req.params.status_code, 10);
     var path = '/' + req.params.path;
     res.redirect(statusCode, path, next);
 }


### PR DESCRIPTION
This PR is related to this suggestion: https://github.com/restify/clients/issues/19

301 and 302 redirects works like 303 - they force a GET request instead of preserving the original HTTP method unless original method is HEAD. Although this behaviour is not specified in RFC7231, almost every client works like this, so I believe it's good to keep the same behaviour. 307 redirects preserve the original HTTP method.

We just follow redirects if the followRedirects option is truthy. It's also possible to specify the maxRedirects option - which limits the number of redirects to follow. maxRedirects default value is 5. If we exceed this limit, a TooManyRedirectsError is thrown.

**Disclaimer**: HttpClient just sends a redirect event - StringClient is responsible for executing the redirect actually. I believe it's not possible to transparently follow redirects on the HttpClient because users manipulate the request object in the callbacks (e.g. end the request or send data). The user callback probably won't work as expected if the HTTP method changes on the redirect (e.g. from POST to GET). If you see a solution to fully handle redirects on HttpClient please let me know!