### PR TITLE
export 'bunyan.serializers', fix client constructor to ensure needed serializers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
-# Current
+# restify-clients Changelog
+
+## 1.3.0
+
+- #65 Export `require('restify-clients').bunyan.serializers` for use in
+  creating the Bunyan logger to pass a client constructor.
+- The clients will now properly ensure that the given
+  [Bunyan](https://github.com/trentm/node-bunyan) logger `log` has the
+  serializers required by logging in this module. This fixes a regression
+  from restify/node-restify#501.
+
+## 1.2.1 and earlier
 - #15 Add audit logger (Marcello de Sales)
 - #22 Follow Redirects (Wagner Francisco Mezaroba)

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -18,10 +18,10 @@ var mime = require('mime');
 var once = require('once');
 var tunnelAgent = require('tunnel-agent');
 
+var bunyanHelper = require('./helpers/bunyan');
 var dtrace = require('./helpers/dtrace');
 var auditor = require('./helpers/auditor');
 var errors = require('restify-errors');
-var serializers = require('./helpers/bunyan').serializers;
 
 // Use native KeepAlive in Node as of 0.11.6
 var semver = require('semver');
@@ -390,7 +390,7 @@ function HttpClient(options) {
     this.connectTimeout = options.connectTimeout || false;
     this.requestTimeout = options.requestTimeout || false;
     this.headers = options.headers || {};
-    this.log = options.log;
+    this.log = bunyanHelper.ensureSerializers(options.log);
     this.followRedirects = options.followRedirects || false;
     this.maxRedirects = options.maxRedirects || 5;
     this.audit = {
@@ -398,11 +398,6 @@ function HttpClient(options) {
         defaultEnabled: options.audit || false
     };
 
-    if (!this.log.serializers) {
-        // Ensure logger has a reasonable serializer for `client_res`
-        // and `client_req` logged in this module.
-        this.log = this.log.child({serializers: serializers});
-    }
     this.key = options.key;
     this.name = options.name || 'HttpClient';
     this.passphrase = options.passphrase;

--- a/lib/helpers/bunyan.js
+++ b/lib/helpers/bunyan.js
@@ -202,6 +202,10 @@ RequestCaptureStream.prototype.toString = function toString() {
 
 ///--- Serializers
 
+/*
+ * Note: `req` and `res` aren't relevant for restify*-clients* but remain for
+ * backward compatibility.
+ */
 var SERIALIZERS = {
     err: bunyan.stdSerializers.err,
     req: bunyan.stdSerializers.req,
@@ -260,6 +264,43 @@ function clientRes(res) {
 }
 
 
+/*
+ * Return the given logger, or a child of it, such that it has the required
+ * log serializers.
+ *
+ * This package logs with some fields for which there should be a serializer
+ * on the logger: `SERIALIZERS`.
+ *
+ * @public
+ * @function ensureSerializers
+ * @param    {Object}   log
+ * @returns  {Object}       the given log, or a child of it with the required
+ *                          serializers
+ */
+function ensureSerializers(log) {
+    assert.object(log, 'log');
+
+    if (!log.serializers) {
+        return log.child({serializers: SERIALIZERS});
+    }
+
+    var haveMissingSerializers = false;
+    var missingSerializers = {};
+    Object.keys(SERIALIZERS).forEach(function (name) {
+        if (!log.serializers[name]) {
+            haveMissingSerializers = true;
+            missingSerializers[name] = SERIALIZERS[name];
+        }
+    });
+
+    if (haveMissingSerializers) {
+        return log.child({serializers: missingSerializers});
+    } else {
+        return log;
+    }
+}
+
+
 /**
  * create a bunyan logger
  * @public
@@ -294,5 +335,6 @@ function createLogger(name) {
 module.exports = {
     RequestCaptureStream: RequestCaptureStream,
     serializers: SERIALIZERS,
+    ensureSerializers: ensureSerializers,
     createLogger: createLogger
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,5 +134,9 @@ module.exports = {
     },
     get StringClient() {
         return StringClient;
+    },
+
+    bunyan: {
+        serializers: bunyan.SERIALIZERS
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-clients",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "lib/index.js",
   "description": "HttpClient, StringClient, and JsonClient extracted from restify",
   "homepage": "http://www.restify.com",

--- a/test/bunyan.js
+++ b/test/bunyan.js
@@ -1,0 +1,160 @@
+/* eslint-disable no-console, no-undefined */
+// jscs:disable maximumLineLength
+
+/*
+ * Test handling for Bunyan logging in restify-clients.
+ */
+
+'use strict';
+
+var assert = require('chai').assert;
+var bunyan = require('bunyan');
+var restify = require('restify');
+
+var clients = require('../lib');
+
+
+///--- Globals
+
+var PORT = process.env.UNIT_TEST_PORT || 0;
+var SERVER;
+
+
+///--- Helpers
+
+function sendJsonPong(req, res, next) {
+    res.header('content-type', 'json');
+    res.send(200, 'pong');
+    next();
+}
+
+function getLog(name, stream, level) {
+    return (bunyan.createLogger({
+        level: (process.env.LOG_LEVEL || level || 'fatal'),
+        name: name || process.argv[1],
+        stream: stream || process.stdout,
+        src: true,
+        serializers: restify.bunyan.serializers
+    }));
+}
+
+function BunyanRecordCapturer() {
+    this.records = [];
+}
+BunyanRecordCapturer.prototype.write = function (record) {
+    this.records.push(record);
+};
+
+
+function assertCreateClientAndValidLog(log, capture, done) {
+    var client = clients.createJsonClient({
+        url: 'http://127.0.0.1:' + PORT,
+        retry: false,
+        log: log
+    });
+    client.get('/json/ping', function (err, req, res, obj) {
+        assert.ifError(err);
+        assert.isAtLeast(capture.records.length, 3);
+        assert.ok(capture.records[0].client_req);
+        assert.deepEqual(Object.keys(capture.records[0].client_req).sort(),
+            ['method', 'url', 'address', 'port', 'headers'].sort());
+        assert.ok(capture.records[1].client_res);
+        assert.deepEqual(Object.keys(capture.records[1].client_res).sort(),
+            ['statusCode', 'headers'].sort());
+        client.close();
+        done();
+    });
+}
+
+
+///--- Tests
+
+describe('restify-client bunyan usage tests', function () {
+
+    before(function (callback) {
+        try {
+            SERVER = restify.createServer({
+                log: getLog('server')
+            });
+
+            SERVER.get('/json/ping', sendJsonPong);
+
+            SERVER.listen(PORT, '127.0.0.1', function () {
+                PORT = SERVER.address().port;
+                setImmediate(callback);
+            });
+        } catch (e) {
+            console.error(e.stack);
+            process.exit(1);
+        }
+    });
+
+
+    after(function (callback) {
+        try {
+            SERVER.close(callback);
+        } catch (e) {
+            console.error(e.stack);
+            process.exit(1);
+        }
+    });
+
+
+    it('no logger', function (done) {
+        var client = clients.createJsonClient({
+            url: 'http://127.0.0.1:' + PORT,
+            retry: false
+        });
+        client.get('/json/ping', function (err, req, res, obj) {
+            assert.ifError(err);
+            assert.ok(req);
+            assert.ok(res);
+            assert.deepEqual(obj, 'pong');
+            client.close();
+            done();
+        });
+    });
+
+    it('no serializers', function (done) {
+        var capture = new BunyanRecordCapturer();
+        var log = bunyan.createLogger({
+            name: 'client',
+            streams: [{type: 'raw', stream: capture, level: 'trace'}]
+        });
+        assertCreateClientAndValidLog(log, capture, done);
+    });
+
+    it('bunyan stdSerializers', function (done) {
+        var capture = new BunyanRecordCapturer();
+        var log = bunyan.createLogger({
+            name: 'client',
+            streams: [{type: 'raw', stream: capture, level: 'trace'}],
+            serializers: bunyan.stdSerializers
+        });
+        assertCreateClientAndValidLog(log, capture, done);
+    });
+
+    it('some unrelated bunyan serializer "foo"', function (done) {
+        var capture = new BunyanRecordCapturer();
+        var log = bunyan.createLogger({
+            name: 'client',
+            streams: [{type: 'raw', stream: capture, level: 'trace'}],
+            serializers: {
+                foo: function serializeFoo(foo) {
+                    return foo;
+                }
+            }
+        });
+        assertCreateClientAndValidLog(log, capture, done);
+    });
+
+    it('using restify-clients exported "bunyan.serializers"', function (done) {
+        var capture = new BunyanRecordCapturer();
+        var log = bunyan.createLogger({
+            name: 'client',
+            streams: [{type: 'raw', stream: capture, level: 'trace'}],
+            serializers: clients.bunyan.serializers
+        });
+        assertCreateClientAndValidLog(log, capture, done);
+    });
+});


### PR DESCRIPTION
Fixes #65
Fixes the regression from restify/node-restify#501