### PR TITLE
fix .eslintrc: duplicate 'comma-dangle' key

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -108,7 +108,6 @@
         // we use JSCS, set most to off because they're on by default.
         // turn the few on that aren't handled by JSCS today.
         "camelcase": [ 0 ],
-        "comma-dangle": [ 0 ],
         "key-spacing": [ 0 ],
         "no-lonely-if": [ 0 ],
         "no-multi-str": [ 0 ],
@@ -130,4 +129,3 @@
         // "no-else-return": [ 2 ]
     }
 }
-


### PR DESCRIPTION
This fixes 'make lint' on master. Currently on master I see this:

https://gist.github.com/trentm/57ec140836355cb06a4f6307beed60ae