### PR TITLE
Add support for .child() on clients with beforeSync and afterSync hooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ be tagged with the appropriate headers.
 If passed, the value of the `beforeSync` parameter should be a function with the
 following prototype:
 
-    function beforeSync(opts) {
+    function beforeSync(opts, ctx) {
 
 where `opts` is an object containing the options for the request. Some things
 you might want to do in this beforeSync function include:
@@ -426,17 +426,22 @@ you might want to do in this beforeSync function include:
  * writing a trace log message indicating that you're making a request
  * modifying opts.headers to include additional headers in the outbound request
 
+The `ctx` option is an empty object which will also be passed to afterSync().
+The beforeSync() function can add any data specific to this request that it
+wants afterSync() to have for this request by attaching it to this object.
+
 If passed, the value of the `afterSync` parameter should be a function with the
 following prototype:
 
-    function afterSync(err, req, res) {
+    function afterSync(err, req, res, ctx) {
 
 which takes an error object (if the request failed), and the
 [req](http://restify.com/#request-api) and
 [res](http://restify.com/#response-api) objects as defined in the restify
-documentation. The `afterSync` caller is most useful for logging the fact that a
-request completed and indicating errors or response details to a tracing
-system.
+documentation. The `ctx` option is the same context object that was passed to
+the `beforeSync` handler for this request (empty Object by default). The
+`afterSync` caller is most useful for logging the fact that a request completed
+and indicating errors or response details to a tracing system.
 
 A full example might be:
 
@@ -445,17 +450,17 @@ A full example might be:
     var client = clients.createJsonClient({url: 'http://127.0.0.1:8080'});
 
     var childClient1 = client.child({
-        beforeSync: function (opts) {
+        beforeSync: function (opts, ctx) {
             opts.headers['client-number'] = 1;
-        }, afterSync: function (err, req, res) {
+        }, afterSync: function (err, req, res, ctx) {
             console.error('code: %d', res.statusCode);
         }
     });
 
     var childClient2 = client.child({
-        beforeSync: function (opts) {
+        beforeSync: function (opts, ctx) {
             opts.headers['client-number'] = 2;
-        }, afterSync: function (err, req, res) {
+        }, afterSync: function (err, req, res, ctx) {
             console.error('code: %d', res.statusCode);
         }
     });

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -647,8 +647,8 @@ function afterCaller(afterFn, err, req) {
         return;
     }
 
-    req.on('result', function _onResult(res_err, res) {
-        res.on('end', function _onEnd() {
+    req.once('result', function _onResult(res_err, res) {
+        res.once('end', function _onEnd() {
             return afterFn(res_err, req, res);
         });
     });

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -648,7 +648,7 @@ function afterCaller(afterFn, err, req) {
     }
 
     req.on('result', function _onResult(res_err, res) {
-        res.on('end', function () {
+        res.on('end', function _onEnd() {
             return afterFn(res_err, req, res);
         });
     });

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -12,6 +12,7 @@ var querystring = require('querystring');
 var url = require('url');
 var util = require('util');
 
+var _ = require('lodash');
 var assert = require('assert-plus');
 var backoff = require('backoff');
 var mime = require('mime');
@@ -400,6 +401,11 @@ function HttpClient(options) {
 
     this.key = options.key;
     this.name = options.name || 'HttpClient';
+
+    // These will be used when tracing is enabled.
+    this._afterSync = null;
+    this._beforeSync = null;
+
     this.passphrase = options.passphrase;
     this.pfx = options.pfx;
 
@@ -514,6 +520,31 @@ util.inherits(HttpClient, EventEmitter);
 module.exports = HttpClient;
 
 
+HttpClient.prototype.child = function child(options) {
+    assert.object(options, 'options');
+
+    var self = this;
+    var childClient;
+
+    assert.ok(!self._afterSync, 'grandchildren not supported');
+    assert.ok(!self._beforeSync, 'grandchildren not supported');
+
+    // We use _.clone() here to create a copy of the parent object so that we
+    // share all the open keepalive connections and the this.agent.
+    childClient = _.clone(self);
+
+    // add before and after hooks if they're passed
+    if (options.beforeSync) {
+        childClient._beforeSync = options.beforeSync;
+    }
+
+    if (options.afterSync) {
+        childClient._afterSync = options.afterSync;
+    }
+
+    return (childClient);
+};
+
 HttpClient.prototype.close = function close() {
     var sockets = this.agent.sockets;
     Object.keys((sockets || {})).forEach(function (k) {
@@ -610,14 +641,44 @@ HttpClient.prototype.basicAuth = function basicAuth(username, password) {
     return (this);
 };
 
+function afterCaller(afterFn, err, req) {
+    if (err) {
+        afterFn(err);
+        return;
+    }
+
+    req.on('result', function _onResult(res_err, res) {
+        res.on('end', function () {
+            return afterFn(res_err, req, res);
+        });
+    });
+}
 
 HttpClient.prototype.request = function request(opts, cb) {
     assert.object(opts, 'options');
     assert.func(cb, 'callback');
 
+    var self = this;
+
+    function _callbackCaller(callback) {
+        return (function _callCallback(err, req) {
+            afterCaller(self._afterSync, err, req);
+
+            // call the original callback
+            return callback.apply(self, arguments);
+        });
+    }
+
     /* eslint-disable no-param-reassign */
+    if (self._afterSync) {
+        cb = _callbackCaller(cb);
+    }
     cb = once(cb);
     /* eslint-enable no-param-reassign */
+
+    if (self._beforeSync) {
+        self._beforeSync(opts);
+    }
 
     opts.audit = this.audit;
 

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -648,6 +648,13 @@ function afterCaller(afterFn, err, req, ctx) {
     }
 
     req.once('result', function _onResult(res_err, res) {
+        if (res_err) {
+            return afterFn(res_err, undefined, undefined, ctx);
+        }
+
+        // res should be set when we don't have a res_err, otherwise it's a bug.
+        assert.ok(res);
+
         res.once('end', function _onEnd() {
             return afterFn(res_err, req, res, ctx);
         });

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -641,7 +641,7 @@ HttpClient.prototype.basicAuth = function basicAuth(username, password) {
     return (this);
 };
 
-function afterCaller(afterFn, err, req) {
+function afterCaller(afterFn, err, req, ctx) {
     if (err) {
         afterFn(err);
         return;
@@ -649,7 +649,7 @@ function afterCaller(afterFn, err, req) {
 
     req.once('result', function _onResult(res_err, res) {
         res.once('end', function _onEnd() {
-            return afterFn(res_err, req, res);
+            return afterFn(res_err, req, res, ctx);
         });
     });
 }
@@ -659,10 +659,12 @@ HttpClient.prototype.request = function request(opts, cb) {
     assert.func(cb, 'callback');
 
     var self = this;
+    // context object passed to both beforeSync and afterSync
+    var ctx = {};
 
     function _callbackCaller(callback) {
         return (function _callCallback(err, req) {
-            afterCaller(self._afterSync, err, req);
+            afterCaller(self._afterSync, err, req, ctx);
 
             // call the original callback
             return callback.apply(self, arguments);
@@ -677,7 +679,7 @@ HttpClient.prototype.request = function request(opts, cb) {
     /* eslint-enable no-param-reassign */
 
     if (self._beforeSync) {
-        self._beforeSync(opts);
+        self._beforeSync(opts, ctx);
     }
 
     opts.audit = this.audit;

--- a/test/index.js
+++ b/test/index.js
@@ -1339,11 +1339,13 @@ describe('restify-client tests', function () {
                 var childClient;
 
                 childClient = _client.handle.child({
-                    beforeSync: function (opts) {
+                    beforeSync: function (opts, ctx) {
                         beforeRan = true;
                         opts.headers['restify-clients-test-header'] = clientName;
-                    }, afterSync: function (err, req, res) {
+                        ctx.helloFromBefore = 'hello';
+                    }, afterSync: function (err, req, res, ctx) {
                         assert.ifError(err);
+                        assert.equal(ctx.helloFromBefore, 'hello');
                         afterRan = true;
                     }
                 });


### PR DESCRIPTION
This change adds support for .child() on HttpClient, StringClient and JsonClient. Child creation takes an object that can have a .beforeSync() and/or .afterSync() function. These functions will be called before and after each request made through the resulting child client. This is especially useful for enabling distributed tracing for restify clients when using a restify server.
