### PR TITLE
switch back to restify-errors@3 to avoid backward incompatible change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,15 @@
 
 ## not yet released
 
+- Switch back to restify-errors@3 to fix backward incompatiblity in
+  `<err>.code` for some error classes. See
+  <https://github.com/restify/clients/pull/42> for discussion.
+
 ## 1.3.1
+
+Note: *Bad release.* This release introduced an update from restify-errors@3 to
+restify-errors@4 which included a backward incompatible change in `<err>.code`
+for created errors. Switch to version 1.3.2 or greater.
 
 - #65 accidentally didn't work. Fix that to correctly export
   `.bunyan.serializers`.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "mime": "^1.3.4",
     "node-uuid": "^1.4.3",
     "once": "^1.3.2",
-    "restify-errors": "^4.2.3",
+    "restify-errors": "^3.1.0",
     "semver": "^5.0.1",
     "tunnel-agent": "^0.4.0"
   }


### PR DESCRIPTION
See discussion at restify/clients#42. That change introduced a backward
incompatible change without a major ver bump of restify-clients.

(Note: I did this as a PR instead of commiting directly in case there is follow-up discussion on this backout.)