### PR TITLE
restify/node-restify#878 HTTP proxy improvments (`http_proxy` et al)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,20 @@
 
 ## not yet released
 
+- restify/node-restify#878 Improved HTTP proxy handling.
+    - There is a new `options.noProxy` option to `create*Client` that overrides
+      the `NO_PROXY` envvar.
+    - `options.proxy` overrides `*_proxy` environment variables (e.g.
+      `HTTPS_PROXY`, `http_proxy`).
+    - Compatibility note: To maintain backward compatibility in 1.x, any of
+      these environment variables (in the order shown, first wins) are used to
+      proxy for http or https URLs: `HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`,
+      `http_proxy`. In a future major version, behaviour might be changed
+      to ignore `HTTPS_PROXY` and `https_proxy` environment variables when
+      proxying a *http* URL. See
+      <https://github.com/restify/node-restify/issues/878#issuecomment-249673285>
+      for discussion.
+
 ## 1.3.3
 
 - Correct usage of `assert.number` (and variants) for update from

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -330,8 +330,6 @@ function proxyOptsFromStr(str) {
     }
     var parsed = url.parse(s);
 
-    // TODO: proxyOpts.headers (see whitelisting of req headers by 'request'
-    // module).
     var proxyOpts = {
         protocol: parsed.protocol,
         host: parsed.hostname
@@ -449,20 +447,20 @@ function HttpClient(options) {
     // HTTP proxy: `options.proxy` wins, else `https_proxy`/`http_proxy` envvars
     // (upper and lowercase) are used.
     if (options.proxy === false) {
-        this.proxy = false;
+        self.proxy = false;
     } else if (options.proxy) {
         if (typeof (options.proxy) === 'string') {
-            this.proxy = proxyOptsFromStr(options.proxy);
+            self.proxy = proxyOptsFromStr(options.proxy);
         } else {
             assert.object(options.proxy, 'options.proxy');
-            this.proxy = options.proxy;
+            self.proxy = options.proxy;
         }
     } else {
         // For backwards compat in restify 4.x and restify-clients 1.x, the
         // `https_proxy` or `http_proxy` envvar will work for both HTTP and
         // HTTPS. That behaviour may change in the next major version. See
         // restify/node-restify#878 for details.
-        this.proxy = proxyOptsFromStr(process.env.https_proxy ||
+        self.proxy = proxyOptsFromStr(process.env.https_proxy ||
             process.env.HTTPS_PROXY ||
             process.env.http_proxy ||
             process.env.HTTP_PROXY);
@@ -471,8 +469,8 @@ function HttpClient(options) {
     var noProxy = (options.hasOwnProperty('noProxy') ? options.noProxy
         : (process.env.NO_PROXY || process.env.no_proxy || null));
 
-    if (this.proxy && !isProxyForURL(noProxy, self.url)) {
-        this.proxy = false;
+    if (self.proxy && !isProxyForURL(noProxy, self.url)) {
+        self.proxy = false;
     }
 
     if (options.accept) {

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -316,10 +316,40 @@ function rawRequest(opts, cb) {
 } // end `rawRequest`
 
 
-//  Check if url is excluded by the no_proxy environment variable
-function isProxyForURL(address) {
-    var noProxy = process.env.NO_PROXY || process.env.no_proxy || null;
+function proxyOptsFromStr(str) {
+    if (!str) {
+        return (false);
+    }
 
+    var s = str;
+
+    // Normalize: host:port -> http://host:port
+    // FWIW `curl` supports using "http_proxy=host:port".
+    if (!/^[a-z0-9]+:\/\//.test(s)) {
+        s = 'http://' + s;
+    }
+    var parsed = url.parse(s);
+
+    // TODO: proxyOpts.headers (see whitelisting of req headers by 'request'
+    // module).
+    var proxyOpts = {
+        protocol: parsed.protocol,
+        host: parsed.hostname
+    };
+
+    if (parsed.port) {
+        proxyOpts.port = Number(parsed.port);
+    }
+
+    if (parsed.auth) {
+        proxyOpts.proxyAuth = parsed.auth;
+    }
+
+    return (proxyOpts);
+}
+
+//  Check if url is excluded by the no_proxy environment variable
+function isProxyForURL(noProxy, address) {
     // wildcard
     if (noProxy === '*') {
         return (null);
@@ -367,6 +397,7 @@ function isProxyForURL(address) {
     }
     return (true);
 }
+
 ///--- API
 
 function HttpClient(options) {
@@ -377,6 +408,7 @@ function HttpClient(options) {
     assert.optionalString(options.socketPath, 'options.socketPath');
     assert.optionalString(options.url, 'options.url');
     assert.optionalBool(options.followRedirects, 'options.followRedirects');
+    assert.optionalString(options.noProxy, 'options.noProxy');
     assert.optionalNumber(options.maxRedirects, 'options.maxRedirects');
 
     EventEmitter.call(this);
@@ -414,17 +446,32 @@ function HttpClient(options) {
     this.socketPath = options.socketPath || false;
     this.url = options.url ? url.parse(options.url) : {};
 
-    if (process.env.https_proxy) {
-        this.proxy = url.parse(process.env.https_proxy);
-    } else if (process.env.http_proxy) {
-        this.proxy = url.parse(process.env.http_proxy);
-    } else if (options.proxy) {
-        this.proxy = options.proxy;
-    } else {
+    // HTTP proxy: `options.proxy` wins, else `https_proxy`/`http_proxy` envvars
+    // (upper and lowercase) are used.
+    if (options.proxy === false) {
         this.proxy = false;
+    } else if (options.proxy) {
+        if (typeof (options.proxy) === 'string') {
+            this.proxy = proxyOptsFromStr(options.proxy);
+        } else {
+            assert.object(options.proxy, 'options.proxy');
+            this.proxy = options.proxy;
+        }
+    } else {
+        // For backwards compat in restify 4.x and restify-clients 1.x, the
+        // `https_proxy` or `http_proxy` envvar will work for both HTTP and
+        // HTTPS. That behaviour may change in the next major version. See
+        // restify/node-restify#878 for details.
+        this.proxy = proxyOptsFromStr(process.env.https_proxy ||
+            process.env.HTTPS_PROXY ||
+            process.env.http_proxy ||
+            process.env.HTTP_PROXY);
     }
 
-    if (this.proxy && !isProxyForURL(self.url)) {
+    var noProxy = (options.hasOwnProperty('noProxy') ? options.noProxy
+        : (process.env.NO_PROXY || process.env.no_proxy || null));
+
+    if (this.proxy && !isProxyForURL(noProxy, self.url)) {
         this.proxy = false;
     }
 

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -1,0 +1,339 @@
+/* eslint-disable no-console, no-undefined */
+// jscs:disable maximumLineLength
+
+/*
+ * Test handling for restify-clients' HTTP proxy handling.
+ */
+
+'use strict';
+
+var assert = require('chai').assert;
+var http = require('http');
+var net = require('net');
+var url = require('url');
+
+var clients = require('../lib');
+
+
+///--- Globals
+
+var PORT = process.env.UNIT_TEST_PORT || 0;
+var PROXYSERVER;
+var PROXYURL;
+var PROXIED = [];
+
+
+///--- Helpers
+
+function stripProcessEnv() {
+    // Ensure envvars don't get in the way.
+    [
+        'HTTP_PROXY',
+        'http_proxy',
+        'HTTPS_PROXY',
+        'https_proxy',
+        'NO_PROXY',
+        'no_proxy'
+    ].forEach(function (n) {
+        delete process.env[n];
+    });
+}
+
+
+///--- Tests
+
+describe('restify-client proxy tests', function () {
+
+    before(function (callback) {
+        try {
+            // A forward-proxy adapted from
+            // JSSTYLED
+            // <https://github.com/nodejitsu/node-http-proxy/blob/master/examples/http/reverse-proxy.js>
+            // (where it is incorrectly named a "reverse" proxy).
+            PROXYSERVER = http.createServer();
+
+            PROXYSERVER.on('connect', function (req, socket) {
+                PROXIED.push({url: req.url, headers: req.headers});
+                var serverUrl = url.parse('https://' + req.url);
+
+                var srvSocket = net.connect(serverUrl.port, serverUrl.hostname,
+                function () {
+                    socket.write('HTTP/1.1 200 Connection Established\r\n' +
+                        'Proxy-agent: Node-Proxy\r\n' +
+                        '\r\n');
+                    srvSocket.pipe(socket);
+                    socket.pipe(srvSocket);
+                });
+            });
+
+            PROXYSERVER.listen(PORT, '127.0.0.1', function () {
+                PORT = PROXYSERVER.address().port;
+                PROXYURL = 'http://127.0.0.1:' + PORT;
+                setImmediate(callback);
+            });
+        } catch (e) {
+            console.error(e.stack);
+            process.exit(1);
+        }
+    });
+
+    after(function (callback) {
+        try {
+            PROXYSERVER.close(callback);
+        } catch (e) {
+            console.error(e.stack);
+            process.exit(1);
+        }
+    });
+
+    it('GET https (without a proxy)', function (done) {
+        stripProcessEnv();
+        PROXIED = [];
+        var client = clients.createStringClient({
+            url: 'https://www.google.com',
+            retry: false
+        });
+        client.get('/', function (err, req, res, body) {
+            assert.ifError(err);
+            assert.equal(PROXIED.length, 0);
+            assert.ok(res.statusCode < 400);
+            client.close();
+            done();
+        });
+    });
+
+    it('GET http (without a proxy)', function (done) {
+        stripProcessEnv();
+        PROXIED = [];
+        var client = clients.createStringClient({
+            url: 'http://www.google.com',
+            retry: false
+        });
+        client.get('/', function (err, req, res, body) {
+            assert.ifError(err);
+            assert.equal(PROXIED.length, 0);
+            assert.ok(res.statusCode < 400);
+            client.close();
+            done();
+        });
+    });
+
+    it('GET https with options.proxy', function (done) {
+        stripProcessEnv();
+        PROXIED = [];
+        var client = clients.createStringClient({
+            url: 'https://www.google.com',
+            proxy: PROXYURL,
+            retry: false
+        });
+        client.get('/', function (err, req, res, body) {
+            assert.ifError(err);
+            assert.equal(PROXIED.length, 1);
+            assert.ok(res.statusCode < 400);
+            client.close();
+            done();
+        });
+    });
+
+    it('GET http with options.proxy', function (done) {
+        stripProcessEnv();
+        PROXIED = [];
+        var client = clients.createStringClient({
+            url: 'http://www.google.com',
+            proxy: PROXYURL,
+            retry: false
+        });
+        client.get('/', function (err, req, res, body) {
+            assert.ifError(err);
+            assert.equal(PROXIED.length, 1);
+            assert.ok(res.statusCode < 400);
+            client.close();
+            done();
+        });
+    });
+
+    [
+        'HTTP_PROXY',
+        'http_proxy',
+        'HTTPS_PROXY',
+        'https_proxy'
+    ].forEach(function (n) {
+        it('GET https with ' + n + ' envvar', function (done) {
+            stripProcessEnv();
+            process.env[n] = PROXYURL;
+            PROXIED = [];
+            var client = clients.createStringClient({
+                url: 'https://www.google.com',
+                retry: false
+            });
+            client.get('/', function (err, req, res, body) {
+                assert.ifError(err);
+                assert.equal(PROXIED.length, 1);
+                assert.ok(res.statusCode < 400);
+                client.close();
+                done();
+            });
+        });
+
+        it('GET http with ' + n + ' envvar', function (done) {
+            stripProcessEnv();
+            process.env[n] = PROXYURL;
+            PROXIED = [];
+            var client = clients.createStringClient({
+                url: 'http://www.google.com',
+                retry: false
+            });
+            client.get('/', function (err, req, res, body) {
+                assert.ifError(err);
+                assert.equal(PROXIED.length, 1);
+                assert.ok(res.statusCode < 400);
+                client.close();
+                done();
+            });
+        });
+    });
+
+    it('options.proxy=PROXYURL wins over envvar', function (done) {
+        stripProcessEnv();
+        process.env.https_proxy = 'https://example.com:1234';
+        PROXIED = [];
+        var client = clients.createStringClient({
+            url: 'https://www.google.com',
+            proxy: PROXYURL,
+            retry: false
+        });
+        client.get('/', function (err, req, res, body) {
+            assert.ifError(err);
+            assert.equal(PROXIED.length, 1);
+            assert.ok(res.statusCode < 400);
+            client.close();
+            done();
+        });
+    });
+
+    it('options.proxy=false wins over envvar', function (done) {
+        stripProcessEnv();
+        process.env.https_proxy = PROXYURL;
+        PROXIED = [];
+        var client = clients.createStringClient({
+            url: 'https://www.google.com',
+            proxy: false,
+            retry: false
+        });
+        client.get('/', function (err, req, res, body) {
+            assert.ifError(err);
+            assert.equal(PROXIED.length, 0);
+            assert.ok(res.statusCode < 400);
+            client.close();
+            done();
+        });
+    });
+
+    it('no_proxy=*', function (done) {
+        stripProcessEnv();
+        process.env.no_proxy = '*';
+        PROXIED = [];
+        var client = clients.createStringClient({
+            url: 'https://www.google.com',
+            proxy: PROXYURL,
+            retry: false
+        });
+        client.get('/', function (err, req, res, body) {
+            assert.ifError(err);
+            assert.equal(PROXIED.length, 0);
+            assert.ok(res.statusCode < 400);
+            client.close();
+            done();
+        });
+    });
+
+    it('NO_PROXY=*', function (done) {
+        stripProcessEnv();
+        process.env.NO_PROXY = '*';
+        PROXIED = [];
+        var client = clients.createStringClient({
+            url: 'https://www.google.com',
+            proxy: PROXYURL,
+            retry: false
+        });
+        client.get('/', function (err, req, res, body) {
+            assert.ifError(err);
+            assert.equal(PROXIED.length, 0);
+            assert.ok(res.statusCode < 400);
+            client.close();
+            done();
+        });
+    });
+
+    it('options.noProxy wins over NO_PROXY envvar', function (done) {
+        stripProcessEnv();
+        process.env.NO_PROXY = '*';
+        PROXIED = [];
+        var client = clients.createStringClient({
+            url: 'https://www.google.com',
+            proxy: PROXYURL,
+            noProxy: '',
+            retry: false
+        });
+        client.get('/', function (err, req, res, body) {
+            assert.ifError(err);
+            assert.equal(PROXIED.length, 1);
+            assert.ok(res.statusCode < 400);
+            client.close();
+            done();
+        });
+    });
+
+    // noProxy values that should result in NOT using the proxy.
+    [
+        '*',
+        'google.com',
+        'www.google.com',
+        'example.com,www.google.com',
+        'example.com, www.google.com'
+    ].forEach(function (noProxy) {
+        it('options.noProxy="' + noProxy + '" (match)', function (done) {
+            stripProcessEnv();
+            PROXIED = [];
+            var client = clients.createStringClient({
+                url: 'https://www.google.com',
+                proxy: PROXYURL,
+                noProxy: noProxy,
+                retry: false
+            });
+            client.get('/', function (err, req, res, body) {
+                assert.ifError(err);
+                assert.equal(PROXIED.length, 0);
+                assert.ok(res.statusCode < 400);
+                client.close();
+                done();
+            });
+        });
+    });
+
+    // noProxy values that should result in USING the proxy.
+    [
+        '.*',
+        'oogle.com',
+        'ww.google.com',
+        'foo.google.com'
+    ].forEach(function (noProxy) {
+        it('options.noProxy="' + noProxy + '" (no match)', function (done) {
+            stripProcessEnv();
+            PROXIED = [];
+            var client = clients.createStringClient({
+                url: 'https://www.google.com',
+                proxy: PROXYURL,
+                noProxy: noProxy,
+                retry: false
+            });
+            client.get('/', function (err, req, res, body) {
+                assert.ifError(err);
+                assert.equal(PROXIED.length, 1);
+                assert.ok(res.statusCode < 400);
+                client.close();
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
See the changelog entry (https://github.com/restify/clients/pull/85/files#diff-8b1c3fd0d4a6765c16dfd18509182f9dR5) and restify/node-restify#878 discussion for notes.