### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/helpers/bunyan.js
+++ b/lib/helpers/bunyan.js
@@ -8,7 +8,7 @@ var util = require('util');
 var assert = require('assert-plus');
 var bunyan = require('bunyan');
 var lru = require('lru-cache');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 
 ///--- Globals

--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
     "lodash": "^4.7.0",
     "lru-cache": "^4.0.1",
     "mime": "^1.3.4",
-    "node-uuid": "^1.4.6",
     "once": "^1.3.2",
     "restify-errors": "^3.1.0",
     "semver": "^5.0.1",
-    "tunnel-agent": "^0.4.0"
+    "tunnel-agent": "^0.4.0",
+    "uuid": "^3.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ var assert = require('chai').assert;
 var bunyan = require('bunyan');
 var crypto = require('crypto');
 var format = require('util').format;
-var uuid   = require('node-uuid');
+var uuid   = require('uuid');
 
 var restify = require('restify');
 var clients = require('../lib');


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.