### PR TITLE
add option to safely stringify circular json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-script
+script:
     make prepush
 node_js:
     - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: node_js
+script
+    make prepush
 node_js:
     - "0.10"
     - "0.12"
     - "4"
+    - "6"
 after_success:
     - make report-coverage
     - make nsp

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 script:
     make prepush
 node_js:
-    - "0.10"
-    - "0.12"
     - "4"
     - "6"
 after_success:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## not yet released
 
+Add a `safeStringify` option to the JSON client to safely stringify request
+bodies that may be circular.
+
 ## 1.4.1
 
 - #90 Fix `<jsonclient>.post(...)` without a body argument.

--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ clean: clean-coverage
 .PHONY: versioncheck
 versioncheck: | node_modules
 	@echo version is: $(shell cat package.json | $(JSON) version)
-	[[ `cat package.json | $(JSON) version` \
-	    == `grep '^## ' CHANGES.md | head -2 | tail -1 | awk '{print $$2}'` ]]
+	[ `cat package.json | $(JSON) version` \
+	    = `grep '^## ' CHANGES.md | head -2 | tail -1 | awk '{print $$2}'` ]
 
 # Confirm, then tag and publish the current version.
 .PHONY: cutarelease

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ it will be an `HttpError`.
 |headers|Object|HTTP headers to set in all requests|
 |log|Object|[bunyan](https://github.com/trentm/node-bunyan) instance|
 |retry|Object|options to provide to node-retry;"false" disables retry; defaults to 4 retries|
+|safeStringify|Boolean|Safely serialize JSON objects, i.e. circular dependencies|
 |signRequest|Function|synchronous callback for interposing headers before request is sent|
 |url|String|Fully-qualified URL to connect to|
 |userAgent|String|user-agent string to use; restify inserts one, but you can override it|

--- a/lib/JsonClient.js
+++ b/lib/JsonClient.js
@@ -6,6 +6,7 @@ var util = require('util');
 
 var assert = require('assert-plus');
 var restifyErrors = require('restify-errors');
+var safeStringify = require('fast-safe-stringify');
 
 var makeErrFromCode = restifyErrors.makeErrFromCode;
 var RestError = restifyErrors.RestError;
@@ -16,6 +17,7 @@ var StringClient = require('./StringClient');
 
 function JsonClient(options) {
     assert.object(options, 'options');
+    assert.optionalBool(options.safeStringify, 'options.safeStringify');
 
     options.accept = 'application/json';
     options.name = options.name || 'JsonClient';
@@ -24,6 +26,8 @@ function JsonClient(options) {
     StringClient.call(this, options);
 
     this._super = StringClient.prototype;
+
+    this._safeStringify = options.safeStringify;
 }
 util.inherits(JsonClient, StringClient);
 
@@ -31,10 +35,18 @@ module.exports = JsonClient;
 
 
 JsonClient.prototype.write = function write(options, body, callback) {
+    var self = this;
+
     var bodyOrDefault = (body !== null ? body : {});
     assert.object(bodyOrDefault, 'body');
 
-    var resBody = JSON.stringify(bodyOrDefault);
+    var resBody;
+    // safely stringify body if client was configured thusly
+    if (self._safeStringify) {
+        resBody = safeStringify(bodyOrDefault);
+    } else {
+        resBody = JSON.stringify(bodyOrDefault);
+    }
     return (this._super.write.call(this, options, resBody, callback));
 };
 

--- a/lib/JsonClient.js
+++ b/lib/JsonClient.js
@@ -27,7 +27,7 @@ function JsonClient(options) {
 
     this._super = StringClient.prototype;
 
-    this._safeStringify = options.safeStringify;
+    this._safeStringify = options.safeStringify || false;
 }
 util.inherits(JsonClient, StringClient);
 

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,7 @@ var JSON_CLIENT;
 var STR_CLIENT;
 var RAW_CLIENT;
 var TIMEOUT_CLIENT;
+var SAFE_STRINGIFY_CLIENT;
 var SERVER;
 
 
@@ -225,11 +226,17 @@ describe('restify-client tests', function () {
                         accept: 'text/plain'
                     }
                 });
-
                 TIMEOUT_CLIENT = clients.createStringClient({
                     url: 'http://127.0.0.1:' + PORT,
                     requestTimeout: 150,
                     retry: false
+                });
+                SAFE_STRINGIFY_CLIENT = clients.createJsonClient({
+                    url: 'http://127.0.0.1:' + PORT,
+                    dtrace: dtrace,
+                    retry: false,
+                    followRedirects: true,
+                    safeStringify: true
                 });
 
                 process.nextTick(callback);
@@ -246,6 +253,8 @@ describe('restify-client tests', function () {
             JSON_CLIENT.close();
             STR_CLIENT.close();
             RAW_CLIENT.close();
+            TIMEOUT_CLIENT.close();
+            SAFE_STRINGIFY_CLIENT.close();
             SERVER.close(callback);
         } catch (e) {
             console.error(e.stack);
@@ -345,6 +354,21 @@ describe('restify-client tests', function () {
         });
     });
 
+    it('POST with circular JSON', function (done) {
+        var data = {
+            hello: 'foo'
+        };
+        data.data = data;
+
+        SAFE_STRINGIFY_CLIENT.post('/json/mcavage', data,
+            function (err, req, res, obj) {
+            assert.ifError(err);
+            assert.ok(req);
+            assert.ok(res);
+            assert.deepEqual(obj, {hello: 'foo'});
+            done();
+        });
+    });
 
     it('POST json empty body object', function (done) {
         var data = {};


### PR DESCRIPTION
@DonutEspresso @rajatkumar Adds an extra `safeStringify` option to the `JSONClient` to safely parse circular JSON.
