### PR TITLE
Use uuid module instead of node-uuid

### DIFF
--- a/lib/helpers/bunyan.js
+++ b/lib/helpers/bunyan.js
@@ -8,7 +8,7 @@ var util = require('util');
 var assert = require('assert-plus');
 var bunyan = require('bunyan');
 var lru = require('lru-cache');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 
 // --- Globals

--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
     "lodash": "^4.7.0",
     "lru-cache": "^4.0.1",
     "mime": "^1.3.4",
-    "node-uuid": "^1.4.6",
     "once": "^1.3.2",
     "restify-errors": "^3.1.0",
     "semver": "^5.0.1",
-    "tunnel-agent": "^0.4.0"
+    "tunnel-agent": "^0.4.0",
+    "uuid": "^3.0.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ var assert = require('chai').assert;
 var bunyan = require('bunyan');
 var crypto = require('crypto');
 var format = require('util').format;
-var uuid   = require('node-uuid');
+var uuid   = require('uuid');
 
 var restify = require('restify');
 var clients = require('../lib');


### PR DESCRIPTION
node-uuid is deprecated
npm WARN deprecated node-uuid@1.4.7: use uuid module instead

You can read more about it over https://github.com/kelektiv/node-uuid/issues/142 and https://github.com/kelektiv/node-uuid/issues/155

Thanks