### PR TITLE
feat: add more context for Request/Connect/DNSTimeoutErrors

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -53,10 +53,7 @@ if (!nativeKeepAlive) {
 
 // --- Globals
 
-var VERSION = JSON.parse(fs.readFileSync(
-    path.join(__dirname, './../package.json'), 'utf8'
-)).version;
-
+var VERSION = require('../package.json').version;
 var REDIRECT_CODES = [301, 302, 303, 307];
 
 // --- Helpers

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -6,6 +6,7 @@
 var EventEmitter = require('events').EventEmitter;
 var http = require('http');
 var https = require('https');
+var net = require('net');
 var os = require('os');
 var querystring = require('querystring');
 var url = require('url');
@@ -129,9 +130,6 @@ function rawRequest(opts, cb) {
             if (req) {
                 req.abort();
             }
-
-            // build connect timeout error using current request options
-            var err = errors.createConnectTimeoutError(opts);
 
             dtrace._rstfy_probes['client-error'].fire(function () {
                 return ([id, err.toString()]);
@@ -307,8 +305,18 @@ function rawRequest(opts, cb) {
             return;
         }
 
-        _socket.once('lookup', function onLookup () {
+        // if the provided url to connect to is already an IP, preemptively set
+        // the remote address.
+        if (net.isIP(opts.hostname)) {
+            req.remoteAddress = opts.hostname;
+        }
+
+        // eslint-disable-next-line handle-callback-err
+        _socket.once('lookup', function onLookup(err, addr, family, host) {
             eventTimes.dnsLookupAt = process.hrtime();
+            // if we had do DNS lookup to resolve hostname, update remote
+            // address now.
+            req.remoteAddress = addr;
         });
 
         _socket.once('secureConnect', function () {

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+// core modules
 var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
 var http = require('http');
@@ -12,20 +13,25 @@ var querystring = require('querystring');
 var url = require('url');
 var util = require('util');
 
+// external modules
+var _ = require('lodash');
 var assert = require('assert-plus');
 var backoff = require('backoff');
+var errors = require('restify-errors');
 var mime = require('mime');
 var once = require('once');
+var semver = require('semver');
 var tunnelAgent = require('tunnel-agent');
+var verror = require('verror');
 
+// local globals
+var auditor = require('./helpers/auditor');
 var bunyanHelper = require('./helpers/bunyan');
 var dtrace = require('./helpers/dtrace');
-var auditor = require('./helpers/auditor');
 var errors = require('restify-errors');
 var getTimingsFromEventTimes = require('./helpers/timings').getTimings;
 
 // Use native KeepAlive in Node as of 0.11.6
-var semver = require('semver');
 var nodeVersion = process.version;
 var nativeKeepAlive = semver.satisfies(nodeVersion, '>=0.11.6');
 var KeepAliveAgent;
@@ -47,11 +53,20 @@ if (!nativeKeepAlive) {
     httpsMaxSockets = Math.min(httpsMaxSockets, 1024);
 }
 
+// require('http').STATUS_CODES has a http 429 error that in < node 4 was known
+// as TooManyRedirects. This has been rectified as TooManyRequests.
+// in the case of restify-clients, we will retain this error type given that
+// users can specify maximum number of redirects to follow.
+if (!errors.TooManyRedirectsError) {
+    errors.makeConstructor('TooManyRedirectsError');
+}
+
+
 // --- Globals
 
-// jscs:disable maximumLineLength
-var VERSION = JSON.parse(fs.readFileSync(path.join(__dirname, './../package.json'), 'utf8')).version;
-// jscs:enable maximumLineLength
+var VERSION = JSON.parse(fs.readFileSync(
+    path.join(__dirname, './../package.json'), 'utf8'
+)).version;
 
 var REDIRECT_CODES = [301, 302, 303, 307];
 
@@ -88,29 +103,103 @@ function defaultUserAgent() {
     return (UA);
 }
 
-if (!errors.TooManyRedirectsError) {
-    errors.makeConstructor('TooManyRedirectsError');
+
+/**
+ * build a request timeout error based for a request.
+ * @private
+ * @function buildRequestTimeoutError
+ * @param {Object} opts options object for a request
+ * @returns {Object} RequestTimeoutError
+ */
+function buildRequestTimeoutError(opts) {
+    assert.object(opts, 'opts');
+
+    var fullUrl = fullRequestUrl(opts);
+    var errMsg = [
+        opts.method,
+        'request to',
+        fullUrl,
+        'failed to complete within',
+        opts.requestTimeout + 'ms'
+    ].join(' ');
+
+    return new verror.VError({
+        name: 'RequestTimeoutError',
+        info: {
+            fullUrl: fullUrl,
+            requestTimeout: opts.requestTimeout
+        }
+    }, errMsg);
 }
 
-function ConnectTimeoutError(ms) {
-    if (Error.captureStackTrace) {
-        Error.captureStackTrace(this, ConnectTimeoutError);
-    }
 
-    this.message = 'connect timeout after ' + ms + 'ms';
-    this.name = 'ConnectTimeoutError';
+/**
+ * build a connect timeout error based for a request.
+ * @private
+ * @function buildConnectionTimeoutError
+ * @param {Object} opts options object for a request
+ * @returns {Object} ConnectionTimeoutError
+ */
+function buildConnectTimeoutError(opts) {
+    assert.object(opts, 'opts');
+
+    var fullUrl = fullRequestUrl(opts);
+    var errMsg = [
+        opts.method,
+        'request to',
+        fullUrl,
+        'failed to obtain connected socket within',
+        opts.connectTimeout + 'ms'
+    ].join(' ');
+
+    return new verror.VError({
+        name: 'ConnectTimeoutError',
+        info: {
+            fullUrl: fullUrl,
+            connectTimeout: opts.connectTimeout
+        }
+    }, errMsg);
 }
-util.inherits(ConnectTimeoutError, Error);
 
-function RequestTimeoutError(ms) {
-    if (Error.captureStackTrace) {
-        Error.captureStackTrace(this, RequestTimeoutError);
-    }
 
-    this.message = 'request timeout after ' + ms + 'ms';
-    this.name = 'RequestTimeoutError';
+/**
+ * given options object for a request, build the fully qualified url. this
+ * method needs to exist primarily a result of the inconsistencies in the
+ * options between node core's API:
+ *      http.request()
+ *      url.parse()
+ * this is not strictly a node issue perse, but rather that this module uses
+ * url.parse() to create the initial "state" of options for http.request(),
+ * then modifies them in a way such that they're no longer compatible with
+ * url modules methods. this is ripe for revisiting at some point later in
+ * time. For reference in the meantime:
+ * https://nodejs.org/api/url.html#url_url_strings_and_url_objects
+ *
+ * the value returned by this function is used only for error
+ * logging/visibility.
+ * @private
+ * @function fullRequestUrl
+ * @param {Object} opts request options
+ * @returns {String}
+ */
+function fullRequestUrl(opts) {
+    assert.object(opts, 'opts');
+
+    // the incoming opts.path value is the value on the request:
+    // i.e., client.get(`opts.path`, function() { ... });
+    // This path value includes any query params as well. the url module calls
+    // this value `pathname`. use a new object so as not to reuse any of the
+    // now mutated values on opts. combine with a select few existing options
+    // to get the fullurl object.
+    var urlObj = _.assign({}, url.parse(opts.path), {
+        protocol: opts.protocol,
+        host: opts.host,
+        port: opts.port
+    });
+
+    return url.format(urlObj);
 }
-util.inherits(RequestTimeoutError, Error);
+
 
 function rawRequest(opts, cb) {
     assert.object(opts, 'options');
@@ -149,7 +238,9 @@ function rawRequest(opts, cb) {
                 req.abort();
             }
 
-            var err = new ConnectTimeoutError(opts.connectTimeout);
+            // build connect timeout error using current request options
+            var err = buildConnectTimeoutError(opts);
+
             dtrace._rstfy_probes['client-error'].fire(function () {
                 return ([id, err.toString()]);
             });
@@ -251,7 +342,7 @@ function rawRequest(opts, cb) {
             requestTimer = setTimeout(function requestTimeout() {
                 requestTimer = null;
 
-                var err = new RequestTimeoutError(opts.requestTimeout);
+                var err = buildRequestTimeoutError(opts);
                 dtrace._rstfy_probes['client-error'].fire(function () {
                     return ([id, err.toString()]);
                 });
@@ -791,6 +882,10 @@ HttpClient.prototype._options = function (method, options) {
         opts.maxRedirects = this.maxRedirects;
     }
 
+    // this.url is an object created from core's url.parse() method. these are
+    // like the "default" options for the client. merge all properties
+    // from this object into the options object IFF they haven't already been
+    // set.
     Object.keys(this.url).forEach(function (k) {
         if (!opts[k]) {
             opts[k] = self.url[k];

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -105,6 +105,34 @@ function defaultUserAgent() {
 
 
 /**
+ * build an http error for an errored request
+ * @private
+ * @function buildHttpError
+ * @param {Object} statusCode response status code
+ * @param {Object} opts options object for a request
+ * @param {Object} req the request object
+ * @returns {Error}
+ */
+function buildHttpError(statusCode, opts, req) {
+    assert.number(statusCode, 'statusCode');
+    assert.object(opts, 'opts');
+    assert.object(req, 'req');
+
+    var fullUrl = fullRequestUrl(opts);
+
+    return errors.makeErrFromCode(statusCode, {
+        context: {
+            address: req.remoteAddress,
+            fullUrl: fullUrl,
+            method: opts.method,
+            port: opts.port,
+            requestTimeout: opts.requestTimeout
+        }
+    });
+}
+
+
+/**
  * build a request timeout error based for a request.
  * @private
  * @function buildRequestTimeoutError
@@ -315,7 +343,7 @@ function rawRequest(opts, cb) {
         var err;
 
         if (res.statusCode >= 400) {
-            err = errors.codeToHttpError(res.statusCode);
+            err = buildHttpError(res.statusCode, opts, req);
         }
 
         req.removeAllListeners('socket');
@@ -389,7 +417,7 @@ function rawRequest(opts, cb) {
         var err;
 
         if (res.statusCode >= 400) {
-            err = errors.codeToHttpError(res.statusCode);
+            err = buildHttpError(res.statusCode, opts, req);
         }
 
         req.removeAllListeners('error');

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -14,21 +14,18 @@ var url = require('url');
 var util = require('util');
 
 // external modules
-var _ = require('lodash');
 var assert = require('assert-plus');
 var backoff = require('backoff');
-var errors = require('restify-errors');
 var mime = require('mime');
 var once = require('once');
 var semver = require('semver');
 var tunnelAgent = require('tunnel-agent');
-var verror = require('verror');
 
 // local globals
 var auditor = require('./helpers/auditor');
 var bunyanHelper = require('./helpers/bunyan');
 var dtrace = require('./helpers/dtrace');
-var errors = require('restify-errors');
+var errors = require('./helpers/errors');
 var getTimingsFromEventTimes = require('./helpers/timings').getTimings;
 
 // Use native KeepAlive in Node as of 0.11.6
@@ -51,14 +48,6 @@ if (!nativeKeepAlive) {
     // never be reused.
     httpMaxSockets = Math.min(httpMaxSockets, 1024);
     httpsMaxSockets = Math.min(httpsMaxSockets, 1024);
-}
-
-// require('http').STATUS_CODES has a http 429 error that in < node 4 was known
-// as TooManyRedirects. This has been rectified as TooManyRequests.
-// in the case of restify-clients, we will retain this error type given that
-// users can specify maximum number of redirects to follow.
-if (!errors.TooManyRedirectsError) {
-    errors.makeConstructor('TooManyRedirectsError');
 }
 
 
@@ -104,131 +93,6 @@ function defaultUserAgent() {
 }
 
 
-/**
- * build an http error for an errored request
- * @private
- * @function buildHttpError
- * @param {Object} statusCode response status code
- * @param {Object} opts options object for a request
- * @param {Object} req the request object
- * @returns {Error}
- */
-function buildHttpError(statusCode, opts, req) {
-    assert.number(statusCode, 'statusCode');
-    assert.object(opts, 'opts');
-    assert.object(req, 'req');
-
-    var fullUrl = fullRequestUrl(opts);
-
-    return errors.makeErrFromCode(statusCode, {
-        context: {
-            address: req.remoteAddress,
-            fullUrl: fullUrl,
-            method: opts.method,
-            port: opts.port,
-            requestTimeout: opts.requestTimeout
-        }
-    });
-}
-
-
-/**
- * build a request timeout error based for a request.
- * @private
- * @function buildRequestTimeoutError
- * @param {Object} opts options object for a request
- * @returns {Object} RequestTimeoutError
- */
-function buildRequestTimeoutError(opts) {
-    assert.object(opts, 'opts');
-
-    var fullUrl = fullRequestUrl(opts);
-    var errMsg = [
-        opts.method,
-        'request to',
-        fullUrl,
-        'failed to complete within',
-        opts.requestTimeout + 'ms'
-    ].join(' ');
-
-    return new verror.VError({
-        name: 'RequestTimeoutError',
-        info: {
-            fullUrl: fullUrl,
-            requestTimeout: opts.requestTimeout
-        }
-    }, errMsg);
-}
-
-
-/**
- * build a connect timeout error based for a request.
- * @private
- * @function buildConnectionTimeoutError
- * @param {Object} opts options object for a request
- * @returns {Object} ConnectionTimeoutError
- */
-function buildConnectTimeoutError(opts) {
-    assert.object(opts, 'opts');
-
-    var fullUrl = fullRequestUrl(opts);
-    var errMsg = [
-        opts.method,
-        'request to',
-        fullUrl,
-        'failed to obtain connected socket within',
-        opts.connectTimeout + 'ms'
-    ].join(' ');
-
-    return new verror.VError({
-        name: 'ConnectTimeoutError',
-        info: {
-            fullUrl: fullUrl,
-            connectTimeout: opts.connectTimeout
-        }
-    }, errMsg);
-}
-
-
-/**
- * given options object for a request, build the fully qualified url. this
- * method needs to exist primarily a result of the inconsistencies in the
- * options between node core's API:
- *      http.request()
- *      url.parse()
- * this is not strictly a node issue perse, but rather that this module uses
- * url.parse() to create the initial "state" of options for http.request(),
- * then modifies them in a way such that they're no longer compatible with
- * url modules methods. this is ripe for revisiting at some point later in
- * time. For reference in the meantime:
- * https://nodejs.org/api/url.html#url_url_strings_and_url_objects
- *
- * the value returned by this function is used only for error
- * logging/visibility.
- * @private
- * @function fullRequestUrl
- * @param {Object} opts request options
- * @returns {String}
- */
-function fullRequestUrl(opts) {
-    assert.object(opts, 'opts');
-
-    // the incoming opts.path value is the value on the request:
-    // i.e., client.get(`opts.path`, function() { ... });
-    // This path value includes any query params as well. the url module calls
-    // this value `pathname`. use a new object so as not to reuse any of the
-    // now mutated values on opts. combine with a select few existing options
-    // to get the fullurl object.
-    var urlObj = _.assign({}, url.parse(opts.path), {
-        protocol: opts.protocol,
-        host: opts.host,
-        port: opts.port
-    });
-
-    return url.format(urlObj);
-}
-
-
 function rawRequest(opts, cb) {
     assert.object(opts, 'options');
     assert.object(opts.log, 'options.log');
@@ -262,12 +126,17 @@ function rawRequest(opts, cb) {
         connectionTimer = setTimeout(function connectTimeout() {
             connectionTimer = null;
 
+            // build connect timeout error using current request options, do
+            // this first before we abort the request so we can pick up socket
+            // information like the ip.
+            var err = errors.createConnectTimeoutErr(opts, req);
+
             if (req) {
                 req.abort();
             }
 
             // build connect timeout error using current request options
-            var err = buildConnectTimeoutError(opts);
+            var err = errors.createConnectTimeoutError(opts);
 
             dtrace._rstfy_probes['client-error'].fire(function () {
                 return ([id, err.toString()]);
@@ -294,8 +163,7 @@ function rawRequest(opts, cb) {
 
         if (opts.maxRedirects &&
             opts.redirects >= opts.maxRedirects) {
-            var msg = 'Aborted after %s redirects';
-            var err = new errors.TooManyRedirectsError(msg, opts.redirects);
+            var err = errors.createTooManyRedirectsErr(opts, req);
             _req.emit('result', err, _res);
         } else {
             opts.redirects = (opts.redirects || 0) + 1;
@@ -343,7 +211,7 @@ function rawRequest(opts, cb) {
         var err;
 
         if (res.statusCode >= 400) {
-            err = buildHttpError(res.statusCode, opts, req);
+            err = errors.createHttpErr(res.statusCode, opts, req);
         }
 
         req.removeAllListeners('socket');
@@ -370,7 +238,7 @@ function rawRequest(opts, cb) {
             requestTimer = setTimeout(function requestTimeout() {
                 requestTimer = null;
 
-                var err = buildRequestTimeoutError(opts);
+                var err = errors.createRequestTimeoutErr(opts, req);
                 dtrace._rstfy_probes['client-error'].fire(function () {
                     return ([id, err.toString()]);
                 });
@@ -417,7 +285,7 @@ function rawRequest(opts, cb) {
         var err;
 
         if (res.statusCode >= 400) {
-            err = buildHttpError(res.statusCode, opts, req);
+            err = errors.createHttpErr(res.statusCode, opts, req);
         }
 
         req.removeAllListeners('error');

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -4,11 +4,9 @@
 
 // core modules
 var EventEmitter = require('events').EventEmitter;
-var fs = require('fs');
 var http = require('http');
 var https = require('https');
 var os = require('os');
-var path = require('path');
 var querystring = require('querystring');
 var url = require('url');
 var util = require('util');

--- a/lib/JsonClient.js
+++ b/lib/JsonClient.js
@@ -91,10 +91,9 @@ JsonClient.prototype.parse = function parse(req, callback) {
                     '';
 
                 resErr = new RestError({
-                    message: _m,
                     restCode: _c,
                     statusCode: res.statusCode
-                });
+                }, '%s', _m);
                 resErr.name = resErr.restCode;
 
                 if (!/Error$/.test(resErr.name)) {
@@ -109,9 +108,7 @@ JsonClient.prototype.parse = function parse(req, callback) {
         // if no http error but we had a json parse error, return the json
         // parse err as the top level error
         if (!resErr && parseErr) {
-            resErr = new RestError(parseErr, {
-                message: 'Invalid JSON in response'
-            });
+            resErr = new RestError(parseErr, 'Invalid JSON in response');
         }
 
         if (resErr) {

--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -181,6 +181,10 @@ function createTooManyRedirectsErr(opts, req) {
  * @private
  * @function fullRequestUrl
  * @param {Object} opts request options
+ * @param {String} opts.path the requested path as set by the user
+ * @param {String} opts.protocol http/https
+ * @param {String} opts.host hostname of the request
+ * @param {String} opts.port port number of the request
  * @returns {String}
  */
 function fullRequestUrl(opts) {

--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -7,36 +7,38 @@ var url = require('url');
 var _ = require('lodash');
 var assert = require('assert-plus');
 var restifyErrors = require('restify-errors');
-var verror = require('verror');
 
-// require('http').STATUS_CODES has a http 429 error that in < node 4 was known
-// as TooManyRedirects. This has been rectified as TooManyRequests.
-// in the case of restify-clients, we will retain this error type given that
-// users can specify maximum number of redirects to follow.
-if (!restifyErrors.TooManyRedirectsError) {
-    restifyErrors.makeConstructor('TooManyRedirectsError');
-}
+
+var ERR_CTOR = {
+    ConnectTimeoutError: restifyErrors.makeConstructor('ConnectTimeoutError'),
+    DNSTimeoutError: restifyErrors.makeConstructor('DNSTimeoutError'),
+    RequestTimeoutError: restifyErrors.makeConstructor('RequestTimeoutError'),
+    TooManyRedirectsError:
+        restifyErrors.makeConstructor('TooManyRedirectsError')
+};
 
 
 /*------------------------------------------------------------------------------
    public methods
 ------------------------------------------------------------------------------*/
 
+
 /**
- * build a connect timeout error based for a request.
+ * build a connect timeout error for a request that failed to resolve DNS or
+ * establish a connection.
  * @public
  * @function createConnectTimeoutErr
  * @param {Object} opts options object for a request
  * @param {Object} req the request object
- * @returns {Object} ConnectionTimeoutError
+ * @returns {verror.VError} ConnectionTimeoutError
  */
 function createConnectTimeoutErr(opts, req) {
     assert.object(opts, 'opts');
     assert.object(req, 'req');
 
-    var errName;
-    var errMsg;
     var errInfo = createErrInfo(opts, req);
+    var errMsg;
+    var errName;
 
     // if remoteAddress has not yet been resolved, DNS resolution could have
     // failed. verify this by checking if the input was an IP to begin with,
@@ -61,8 +63,7 @@ function createConnectTimeoutErr(opts, req) {
         ].join(' ');
     }
 
-    return new verror.VError({
-        name: errName,
+    return new ERR_CTOR[errName]({
         info: _.assign(errInfo, {
             connectTimeout: opts.connectTimeout
         })
@@ -71,13 +72,14 @@ function createConnectTimeoutErr(opts, req) {
 
 
 /**
- * build an http error for an errored request
+ * build an http error for a request that has a corresponding http status code
+ * on the response.
  * @private
  * @function createHttpErr
  * @param {Object} statusCode response status code
  * @param {Object} opts options object for a request
  * @param {Object} req the request object
- * @returns {Error}
+ * @returns {verror.VError}
  */
 function createHttpErr(statusCode, opts, req) {
     assert.number(statusCode, 'statusCode');
@@ -93,12 +95,13 @@ function createHttpErr(statusCode, opts, req) {
 
 
 /**
- * build a request timeout error based for a request.
+ * build a request timeout error for a request that failed to complete within
+ * the specified timeout period.
  * @private
  * @function createRequestTimeoutErr
  * @param {Object} opts options object for a request
  * @param {Object} req the request object
- * @returns {Object} RequestTimeoutError
+ * @returns {verror.VError} RequestTimeoutError
  */
 function createRequestTimeoutErr(opts, req) {
     assert.object(opts, 'opts');
@@ -113,8 +116,7 @@ function createRequestTimeoutErr(opts, req) {
         opts.requestTimeout + 'ms'
     ].join(' ');
 
-    return new verror.VError({
-        name: 'RequestTimeoutError',
+    return new ERR_CTOR.RequestTimeoutError({
         info: _.assign(errInfo, {
             requestTimeout: opts.requestTimeout
         })
@@ -122,7 +124,15 @@ function createRequestTimeoutErr(opts, req) {
 }
 
 
-
+/**
+ * build a redirect error for a request that encountered too many redirects
+ * when attempting to follow redirects.
+ * @private
+ * @function createRequestTimeoutErr
+ * @param {Object} opts options object for a request
+ * @param {Object} req the request object
+ * @returns {verror.VError} RequestTimeoutError
+ */
 function createTooManyRedirectsErr(opts, req) {
     assert.object(opts, 'opts');
     assert.object(req, 'req');
@@ -138,8 +148,7 @@ function createTooManyRedirectsErr(opts, req) {
         'redirects'
     ].join(' ');
 
-    return new verror.VError({
-        name: 'TooManyRedirectsError',
+    return new ERR_CTOR.TooManyRedirectsError({
         info: _.assign(errInfo, {
             // add additional context relevant for redirects
             numRedirects: opts.redirects,

--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -1,0 +1,227 @@
+'use strict';
+
+// core modules
+var url = require('url');
+
+// external modules
+var _ = require('lodash');
+var assert = require('assert-plus');
+var restifyErrors = require('restify-errors');
+var verror = require('verror');
+
+// require('http').STATUS_CODES has a http 429 error that in < node 4 was known
+// as TooManyRedirects. This has been rectified as TooManyRequests.
+// in the case of restify-clients, we will retain this error type given that
+// users can specify maximum number of redirects to follow.
+if (!restifyErrors.TooManyRedirectsError) {
+    restifyErrors.makeConstructor('TooManyRedirectsError');
+}
+
+
+/*------------------------------------------------------------------------------
+   public methods
+------------------------------------------------------------------------------*/
+
+/**
+ * build a connect timeout error based for a request.
+ * @public
+ * @function createConnectTimeoutErr
+ * @param {Object} opts options object for a request
+ * @param {Object} req the request object
+ * @returns {Object} ConnectionTimeoutError
+ */
+function createConnectTimeoutErr(opts, req) {
+    assert.object(opts, 'opts');
+    assert.object(req, 'req');
+
+    var errName;
+    var errMsg;
+    var errInfo = createErrInfo(opts, req);
+
+    // if remoteAddress has not yet been resolved, DNS resolution could have
+    // failed. verify this by checking if the input was an IP to begin with,
+    // if it was, lookup was never called anyway so its a real connect timeout
+    // error.
+    if (!req.remoteAddress) {
+        errName = 'DNSTimeoutError';
+        errMsg = [
+            'failed to resolve hostname',
+            '`' + opts.hostname + '`',
+            'within',
+            opts.connectTimeout + 'ms'
+        ].join(' ');
+    } else {
+        errName = 'ConnectTimeoutError';
+        errMsg = [
+            opts.method,
+            'request to',
+            errInfo.fullUrl,
+            'failed to obtain connected socket within',
+            opts.connectTimeout + 'ms'
+        ].join(' ');
+    }
+
+    return new verror.VError({
+        name: errName,
+        info: _.assign(errInfo, {
+            connectTimeout: opts.connectTimeout
+        })
+    }, '%s', errMsg);
+}
+
+
+/**
+ * build an http error for an errored request
+ * @private
+ * @function createHttpErr
+ * @param {Object} statusCode response status code
+ * @param {Object} opts options object for a request
+ * @param {Object} req the request object
+ * @returns {Error}
+ */
+function createHttpErr(statusCode, opts, req) {
+    assert.number(statusCode, 'statusCode');
+    assert.object(opts, 'opts');
+    assert.object(req, 'req');
+
+    var errInfo = createErrInfo(opts, req);
+
+    return restifyErrors.makeErrFromCode(statusCode, {
+        info: errInfo
+    });
+}
+
+
+/**
+ * build a request timeout error based for a request.
+ * @private
+ * @function createRequestTimeoutErr
+ * @param {Object} opts options object for a request
+ * @param {Object} req the request object
+ * @returns {Object} RequestTimeoutError
+ */
+function createRequestTimeoutErr(opts, req) {
+    assert.object(opts, 'opts');
+    assert.object(req, 'req');
+
+    var errInfo = createErrInfo(opts, req);
+    var errMsg = [
+        opts.method,
+        'request to',
+        errInfo.fullUrl,
+        'failed to complete within',
+        opts.requestTimeout + 'ms'
+    ].join(' ');
+
+    return new verror.VError({
+        name: 'RequestTimeoutError',
+        info: _.assign(errInfo, {
+            requestTimeout: opts.requestTimeout
+        })
+    }, '%s', errMsg);
+}
+
+
+
+function createTooManyRedirectsErr(opts, req) {
+    assert.object(opts, 'opts');
+    assert.object(req, 'req');
+
+    var errInfo = createErrInfo(opts, req);
+    var errMsg = [
+        'aborted',
+        opts.method,
+        'request to',
+        errInfo.fullUrl,
+        'after',
+        opts.redirects,
+        'redirects'
+    ].join(' ');
+
+    return new verror.VError({
+        name: 'TooManyRedirectsError',
+        info: _.assign(errInfo, {
+            // add additional context relevant for redirects
+            numRedirects: opts.redirects,
+            maxRedirects: opts.maxRedirects
+        })
+    }, '%s', errMsg);
+}
+
+
+/*------------------------------------------------------------------------------
+   private methods
+------------------------------------------------------------------------------*/
+
+
+/**
+ * given options object for a request, build the fully qualified url. this
+ * method needs to exist primarily a result of the inconsistencies in the
+ * options between node core's API:
+ *      http.request()
+ *      url.parse()
+ * this is not strictly a node issue perse, but rather that this module uses
+ * url.parse() to create the initial "state" of options for http.request(),
+ * then modifies them in a way such that they're no longer compatible with
+ * url modules methods. this is ripe for revisiting at some point later in
+ * time. For reference in the meantime:
+ * https://nodejs.org/api/url.html#url_url_strings_and_url_objects
+ *
+ * the value returned by this function is used only for error
+ * logging/visibility.
+ * @private
+ * @function fullRequestUrl
+ * @param {Object} opts request options
+ * @returns {String}
+ */
+function fullRequestUrl(opts) {
+    assert.object(opts, 'opts');
+
+    // the incoming opts.path value is the value on the request:
+    // i.e., client.get(`opts.path`, function() { ... });
+    // This path value includes any query params as well. the url module calls
+    // this value `pathname`. use a new object so as not to reuse any of the
+    // now mutated values on opts. combine with a select few existing options
+    // to get the fullurl object.
+    var urlObj = _.assign({}, url.parse(opts.path), {
+        protocol: opts.protocol,
+        host: opts.host,
+        port: opts.port
+    });
+
+    return url.format(urlObj);
+}
+
+
+/**
+ * create an info object for use with verror given the opts object used to
+ * issue the original request, along with the request object itself.
+ * @private
+ * @function createErrInfo
+ * @param {Object} opts an options object
+ * @param {Object} req a request object
+ * @returns {Object}
+ */
+function createErrInfo(opts, req) {
+    assert.object(opts, 'opts');
+    assert.object(req, 'req');
+
+    return {
+        // port and address can both be unpopulated - fall back on null so
+        // that they can both be null (instead of req.remoteAddress
+        // defaulting to undefined)
+        address: req.remoteAddress || null,
+        fullUrl: fullRequestUrl(opts),
+        method: opts.method,
+        port: opts.port
+    };
+}
+
+
+
+module.exports = {
+    createConnectTimeoutErr: createConnectTimeoutErr,
+    createHttpErr: createHttpErr,
+    createRequestTimeoutErr: createRequestTimeoutErr,
+    createTooManyRedirectsErr: createTooManyRedirectsErr
+};

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "semver": "^5.0.1",
     "tunnel-agent": "^0.6.0",
     "uuid": "^3.0.1"
+    "verror": "^1.9.0"
   },
   "optionalDependency": {
     "dtrace-provider": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "restify-errors": "git+https://git@github.com/restify/errors#verror-base",
     "semver": "^5.0.1",
     "tunnel-agent": "^0.6.0",
-    "uuid": "^3.0.1",
-    "verror": "^1.9.0"
+    "uuid": "^3.0.1"
   },
   "optionalDependency": {
     "dtrace-provider": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lru-cache": "^4.0.1",
     "mime": "^1.4.1",
     "once": "^1.3.2",
-    "restify-errors": "git+https://git@github.com/restify/errors#verror-base",
+    "restify-errors": "^6.0.0",
     "semver": "^5.0.1",
     "tunnel-agent": "^0.6.0",
     "uuid": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lru-cache": "^4.0.1",
     "mime": "^1.4.1",
     "once": "^1.3.2",
-    "restify-errors": "^3.0.0",
+    "restify-errors": "git+https://git@github.com/restify/errors#verror-base",
     "semver": "^5.0.1",
     "tunnel-agent": "^0.6.0",
     "uuid": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "restify-errors": "^3.1.0",
     "semver": "^5.0.1",
     "tunnel-agent": "^0.6.0",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
     "verror": "^1.9.0"
   },
   "optionalDependency": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lru-cache": "^4.0.1",
     "mime": "^1.4.1",
     "once": "^1.3.2",
-    "restify-errors": "^3.1.0",
+    "restify-errors": "^3.0.0",
     "semver": "^5.0.1",
     "tunnel-agent": "^0.6.0",
     "uuid": "^3.0.1",

--- a/test/errors.js
+++ b/test/errors.js
@@ -21,7 +21,6 @@ var REST_CODES = [
     { name: 'InvalidVersionError', code: 400 },
     { name: 'MissingParameterError', code: 409 },
     { name: 'NotAuthorizedError', code: 403 },
-    { name: 'PreconditionFailedError', code: 412 },
     { name: 'RequestExpiredError', code: 400 },
     { name: 'RequestThrottledError', code: 429 },
     { name: 'ResourceNotFoundError', code: 404 },
@@ -43,7 +42,7 @@ var HTTP_CODES = [
     { name: 'LengthRequiredError', code: 411 },
     // The PreconditionFailedError exported by restify-errors is
     // actually a RestError, and not an HttpError:
-    // { name: 'PreconditionFailedError', code: 412 },
+    { name: 'PreconditionFailedError', code: 412 },
     { name: 'UnsupportedMediaTypeError', code: 415 },
     { name: 'ExpectationFailedError', code: 417 },
     { name: 'ImATeapotError', code: 418 },
@@ -127,12 +126,13 @@ describe('errors are part of the interface', function () {
 
     it('check that HttpErrors are correct', function (done) {
         HTTP_CODES.forEach(function (info) {
+            var shortName = info.name.replace(/Error$/, '');
             var constructor = errors[info.name];
             assert.isOk(constructor, info.name);
 
             var err = new constructor();
             assert.deepEqual(info.name, err.name);
-            assert.deepEqual(info.name, err.body.code);
+            assert.deepEqual(shortName, err.body.code);
             assert.deepEqual(info.code, err.statusCode);
             assert.isOk(err instanceof errors.HttpError);
         });

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -5,6 +5,7 @@ var dns = require('dns');
 var assert = require('chai').assert;
 var bunyan = require('bunyan');
 var restify = require('restify');
+var restifyErrs = require('restify-errors');
 
 var clients = require('../lib');
 
@@ -46,7 +47,7 @@ describe('Error factories', function () {
         }, function (err, req) {
             assert.ok(err);
             assert.strictEqual(err.name, 'ConnectTimeoutError');
-            assert.deepEqual(err.info(), {
+            assert.deepEqual(restifyErrs.info(err), {
                 address: '10.255.255.1',
                 connectTimeout: 200,
                 fullUrl: 'http://10.255.255.1:81/foo?a=1',
@@ -78,7 +79,7 @@ describe('Error factories', function () {
         }, function (err, req) {
             assert.ok(err);
             assert.strictEqual(err.name, 'DNSTimeoutError');
-            assert.deepEqual(err.info(), {
+            assert.deepEqual(restifyErrs.info(err), {
                 address: null,
                 connectTimeout: 200,
                 fullUrl: 'http://www.restify.com/foo?a=1',
@@ -117,7 +118,7 @@ describe('Error factories', function () {
                 'http://127.0.0.1:' + PORT + '/timeout ' +
                 'failed to complete within 150ms'
             );
-            assert.deepEqual(err.info(), {
+            assert.deepEqual(restifyErrs.info(err), {
                 address: '127.0.0.1',
                 fullUrl: 'http://127.0.0.1:' + PORT + '/timeout',
                 method: 'GET',
@@ -141,7 +142,7 @@ describe('Error factories', function () {
         CLIENT.get('/500', function (err, req, res, obj) {
             assert.isTrue(err instanceof Error);
             assert.strictEqual(err.name, 'InternalServerError');
-            assert.deepEqual(err.info(), {
+            assert.deepEqual(restifyErrs.info(err), {
                 address: '127.0.0.1',
                 fullUrl: 'http://127.0.0.1:' + PORT + '/500',
                 method: 'GET',

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -5,7 +5,6 @@ var dns = require('dns');
 var assert = require('chai').assert;
 var bunyan = require('bunyan');
 var restify = require('restify');
-var verror = require('verror');
 
 var clients = require('../lib');
 
@@ -47,7 +46,7 @@ describe('Error factories', function () {
         }, function (err, req) {
             assert.ok(err);
             assert.strictEqual(err.name, 'ConnectTimeoutError');
-            assert.deepEqual(verror.info(err), {
+            assert.deepEqual(err.info(), {
                 address: '10.255.255.1',
                 connectTimeout: 200,
                 fullUrl: 'http://10.255.255.1:81/foo?a=1',
@@ -79,7 +78,7 @@ describe('Error factories', function () {
         }, function (err, req) {
             assert.ok(err);
             assert.strictEqual(err.name, 'DNSTimeoutError');
-            assert.deepEqual(verror.info(err), {
+            assert.deepEqual(err.info(), {
                 address: null,
                 connectTimeout: 200,
                 fullUrl: 'http://www.restify.com/foo?a=1',
@@ -118,7 +117,7 @@ describe('Error factories', function () {
                 'http://127.0.0.1:' + PORT + '/timeout ' +
                 'failed to complete within 150ms'
             );
-            assert.deepEqual(verror.info(err), {
+            assert.deepEqual(err.info(), {
                 address: '127.0.0.1',
                 fullUrl: 'http://127.0.0.1:' + PORT + '/timeout',
                 method: 'GET',
@@ -142,7 +141,7 @@ describe('Error factories', function () {
         CLIENT.get('/500', function (err, req, res, obj) {
             assert.isTrue(err instanceof Error);
             assert.strictEqual(err.name, 'InternalServerError');
-            assert.deepEqual(verror.info(err), {
+            assert.deepEqual(err.info(), {
                 address: '127.0.0.1',
                 fullUrl: 'http://127.0.0.1:' + PORT + '/500',
                 method: 'GET',

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+var dns = require('dns');
+
+var assert = require('chai').assert;
+var bunyan = require('bunyan');
+var restify = require('restify');
+var verror = require('verror');
+
+var clients = require('../lib');
+
+
+describe('Error factories', function () {
+
+    var SERVER;
+    var CLIENT;
+    var PORT = 3000;
+
+    beforeEach(function (done) {
+        SERVER = restify.createServer({
+            log: bunyan.createLogger({
+                name: 'server'
+            }),
+            handleUncaughtExceptions: false
+        });
+
+        SERVER.listen(PORT, done);
+    });
+
+    afterEach(function (done) {
+        CLIENT.close();
+        SERVER.close(done);
+    });
+
+
+    it('should return ConnectTimeoutError on connect timeout', function (done) {
+        CLIENT = clients.createClient({
+            url: 'http://10.255.255.1:81',
+            connectTimeout: 200,
+            retry: false,
+            agent: false
+        });
+
+        CLIENT.get({
+            path: '/foo',
+            query: { a: 1 }
+        }, function (err, req) {
+            assert.ok(err);
+            assert.strictEqual(err.name, 'ConnectTimeoutError');
+            assert.deepEqual(verror.info(err), {
+                address: '10.255.255.1',
+                connectTimeout: 200,
+                fullUrl: 'http://10.255.255.1:81/foo?a=1',
+                method: 'GET',
+                port: '81'
+            });
+            done();
+        });
+    });
+
+
+    it('should return DNSTimeoutError when dns resolution times out',
+    function (done) {
+        dns.oldLookup = dns.lookup;
+        dns.lookup = function interceptLookup() {
+            // do nothing, so it will stall and timeout
+        };
+
+        CLIENT = clients.createClient({
+            url: 'http://www.restify.com',
+            connectTimeout: 200,
+            retry: false,
+            agent: false
+        });
+
+        CLIENT.get({
+            path: '/foo',
+            query: { a: 1 }
+        }, function (err, req) {
+            assert.ok(err);
+            assert.strictEqual(err.name, 'DNSTimeoutError');
+            assert.deepEqual(verror.info(err), {
+                address: null,
+                connectTimeout: 200,
+                fullUrl: 'http://www.restify.com/foo?a=1',
+                method: 'GET',
+                port: null
+            });
+
+            // restore dns behavior
+            dns.lookup = dns.oldLookup;
+            delete dns.oldLookup;
+            return done();
+        });
+    });
+
+
+    it('should return RequestTimeoutError on request timeout', function (done) {
+        CLIENT = clients.createStringClient({
+            url: 'http://127.0.0.1:' + PORT,
+            requestTimeout: 150,
+            retry: false
+        });
+
+        SERVER.get('/timeout', function (req, res, next) {
+            setTimeout(function () {
+                res.send('OK');
+                next();
+            }, 170);
+        });
+
+        CLIENT.get('/timeout', function (err, req, res, obj) {
+            assert.isTrue(err instanceof Error);
+            assert.equal(err.name, 'RequestTimeoutError');
+            assert.equal(
+                err.message,
+                'GET request to ' +
+                'http://127.0.0.1:' + PORT + '/timeout ' +
+                'failed to complete within 150ms'
+            );
+            assert.deepEqual(verror.info(err), {
+                address: '127.0.0.1',
+                fullUrl: 'http://127.0.0.1:' + PORT + '/timeout',
+                method: 'GET',
+                port: PORT.toString(),
+                requestTimeout: 150
+            });
+            done();
+        });
+    });
+
+
+    it('should return error info for 4xx/5xx http errors', function (done) {
+        CLIENT = clients.createStringClient({
+            url: 'http://127.0.0.1:' + PORT
+        });
+
+        SERVER.get('/500', function (req, res, next) {
+            res.send(500, 'boom');
+        });
+
+        CLIENT.get('/500', function (err, req, res, obj) {
+            assert.isTrue(err instanceof Error);
+            assert.strictEqual(err.name, 'InternalServerError');
+            assert.deepEqual(verror.info(err), {
+                address: '127.0.0.1',
+                fullUrl: 'http://127.0.0.1:' + PORT + '/500',
+                method: 'GET',
+                port: PORT.toString()
+            });
+            return done();
+        });
+    });
+});

--- a/tools/nspBadge.js
+++ b/tools/nspBadge.js
@@ -6,11 +6,9 @@ var fs = require('fs');
 var path = require('path');
 
 var README_PATH = path.join(__dirname, '../README.md');
-/* jscs:disable maximumLineLength */
 var FAIL_BADGE = 'vulnerabilities%20found-red';
 var SUCCESS_BADGE = 'no%20vulnerabilities-green';
 var NSP_LINE_ID = '[NSP Status]';
-/* jscs:enable maximumLineLength */
 
 process.stdin.on('data', function(exitCodeBuf) {
 


### PR DESCRIPTION
Addresses #104. 

Here are example errors of both classes:

```
{ ConnectTimeoutError: GET request to http://169.254.1.10/foo?a=1 failed to obtain connected socket within 100ms
    at buildConnectTimeoutError (/Users/aliu/Sandbox/restify-clients/lib/HttpClient.js:153:12)
    at Timeout.connectTimeout [as _onTimeout] (/Users/aliu/Sandbox/restify-clients/lib/HttpClient.js:231:23)
    at ontimeout (timers.js:365:14)
    at tryOnTimeout (timers.js:237:5)
    at Timer.listOnTimeout (timers.js:207:5)
  name: 'ConnectTimeoutError',
  jse_shortmsg: 'GET request to http://169.254.1.10/foo?a=1 failed to obtain connected socket within 100ms',
  jse_info: { fullUrl: 'http://169.254.1.10/foo?a=1', connectTimeout: 100 },
  message: 'GET request to http://169.254.1.10/foo?a=1 failed to obtain connected socket within 100ms' }
```

```
{ RequestTimeoutError: GET request to http://127.0.0.1:53927/str/request_timeout failed to complete within 150ms
    at buildRequestTimeoutError (/Users/aliu/Sandbox/restify-clients/lib/HttpClient.js:124:12)
    at Timeout.requestTimeout [as _onTimeout] (/Users/aliu/Sandbox/restify-clients/lib/HttpClient.js:383:31)
    at ontimeout (timers.js:365:14)
    at tryOnTimeout (timers.js:237:5)
    at Timer.listOnTimeout (timers.js:207:5)
  name: 'RequestTimeoutError',
  jse_shortmsg: 'GET request to http://127.0.0.1:53927/str/request_timeout failed to complete within 150ms',
  jse_info:
   { fullUrl: 'http://127.0.0.1:53927/str/request_timeout',
     requestTimeout: 150 },
  message: 'GET request to http://127.0.0.1:53927/str/request_timeout failed to complete within 150ms' }
```

I'm looking for feedback on two items:

1) Do we want to attach more fields onto the verror `info`object? The full URL can be parsed by url.parse() to get any of the derived fields (hostname, path, protocol, port, etc.) but I'm happy to directly attach the results of url.parse() to the `info` object as well. 

2) The initial feedback in #104 sounded like we might want to have an underlying error which could be used as a cause for ConnectTimeout or RequestTimeout - but both of these seem pretty low level as is, so I decided to just attach the relevant metadata directly into `info` object. Would be happy to hear alternative approaches here. 