### PR TITLE
Use options.accept and contentType when provided

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,7 +61,7 @@
         "no-loop-func": [ 2 ],
         "no-multi-spaces": [ 0 ],
         "no-native-reassign": [ 2 ],
-        "no-new": [ 2 ],
+        "no-new": [ 0 ],
         "no-new-func": [ 2 ],
         "no-new-wrappers": [ 2 ],
         "no-octal": [ 2 ],

--- a/lib/JsonClient.js
+++ b/lib/JsonClient.js
@@ -19,9 +19,9 @@ function JsonClient(options) {
     assert.object(options, 'options');
     assert.optionalBool(options.safeStringify, 'options.safeStringify');
 
-    options.accept = 'application/json';
+    options.accept = options.accept || 'application/json';
     options.name = options.name || 'JsonClient';
-    options.contentType = 'application/json';
+    options.contentType = options.contentType || 'application/json';
 
     StringClient.call(this, options);
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "Mihir Rege",
     "Ray Solomon",
     "Trent Mick",
+    "Vinicius Kiatkoski Neves",
     "Vladimir Bulyga",
     "Wagner Francisco Mezaroba"
   ],
@@ -54,7 +55,9 @@
     "mocha": "^3.4.2",
     "nock": "^9.0.13",
     "nsp": "^2.0.1",
-    "restify": "^4.3.0"
+    "proxyquire": "^1.8.0",
+    "restify": "^4.3.0",
+    "sinon": "^4.1.2"
   },
   "dependencies": {
     "assert-plus": "^1.0.0",

--- a/test/JsonClient.js
+++ b/test/JsonClient.js
@@ -4,7 +4,7 @@ var assert = require('chai').assert;
 var proxyquire = require('proxyquire');
 var sinon = require('sinon');
 
-describe.only('restify-clients JsonClient tests', function () {
+describe('restify-clients JsonClient tests', function () {
 
     var JsonClient;
     var StringClient;

--- a/test/JsonClient.js
+++ b/test/JsonClient.js
@@ -1,0 +1,96 @@
+'use strict'
+
+var assert = require('chai').assert;
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+
+describe.only('restify-clients JsonClient tests', function () {
+
+    var JsonClient;
+    var StringClient;
+
+    before(function (callback) {
+        StringClient = sinon.spy();
+
+        JsonClient = proxyquire('../lib/JsonClient', {
+            './StringClient': StringClient
+        });
+
+        callback();
+    });
+
+    it('should set options.accept to "application/json" by default',
+        function () {
+            var options = {};
+            new JsonClient(options);
+
+            assert.equal('application/json', options.accept);
+        }
+    );
+
+    it('should set options.name to "JsonClient" by default', function () {
+        var options = {};
+        new JsonClient(options);
+
+        assert.equal('JsonClient', options.name);
+    });
+
+    it('should set options.contentType to "application/json" by default',
+        function () {
+            var options = {};
+            new JsonClient(options);
+
+            assert.equal('application/json', options.contentType);
+        }
+    );
+
+    it('should set _safeStringify to "false" as default', function () {
+        var options = {};
+        var newClient = new JsonClient(options);
+
+        assert.equal(false, newClient._safeStringify);
+    });
+
+    it('should call StringClient with options', function () {
+        var options = {};
+        new JsonClient(options);
+
+        assert.isOk(StringClient.calledWith(options));
+    });
+
+    it('should overwrite options.accept when provided', function () {
+        var options = {
+            accept: 'text/plain'
+        };
+        new JsonClient(options);
+
+        assert.equal('text/plain', options.accept);
+    });
+
+    it('should overwrite options.name when provided', function () {
+        var options = {
+            name: 'MyCustomClient'
+        };
+        new JsonClient(options);
+
+        assert.equal('MyCustomClient', options.name);
+    });
+
+    it('should overwrite options.contentType when provided', function () {
+        var options = {
+            contentType: 'application/vnd.trustvox-v2+json'
+        };
+        new JsonClient(options);
+
+        assert.equal('application/vnd.trustvox-v2+json', options.contentType);
+    });
+
+    it('should overwrite _safeStringify when provided', function () {
+        var options = {
+            safeStringify: true
+        };
+        var newClient = new JsonClient(options);
+
+        assert.equal(true, newClient._safeStringify);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -309,7 +309,7 @@ describe('restify-client tests', function () {
             });
         } catch (err) {
             assert.ok(err);
-            assert.equal(err.constructor, TypeError);
+            assert.equal(err instanceof TypeError, true);
             var errMsgRe = /^Request path contains unescaped characters\.?$/;
             assert.ok(errMsgRe.test(err.message),
                 format('error message matches %s: %j', errMsgRe, err.message));


### PR DESCRIPTION
Related to: https://github.com/restify/clients/issues/127

We were facing issues when 'accept' header was something like: "application/vnd.trustvox-v2+json".

I think it should be possible to update both: 'accept' and 'contentType' headers as other ``StringClient`` (https://github.com/restify/clients/blob/master/lib/StringClient.js#L21)

I will also update documentation that is missing 'contentType' option.