### PR TITLE
feat: support retries without exponential backoff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,13 @@
 * #148: JSONClient is now strict about valid responses. Non JSON responses
   return parse errors to the caller. HTTP errors supersede parse errors. JSONP
   is also no longer supported. Empty responses return an empty pojo `{}`.
+* #149: On retries, the `attempt` event was renamed to `retry`.
+
+### New ###
+* #149: Introduced a `req.getAttempts()` API which returns the number of
+  attempts made to establish a connection.
+* #149: Introduced `opts.exponentialBackoff: false` flag to allow retries
+  without exponential backoff.
 
 ### Fix ###
 * #132: Handle multibyte characters properly in gzipped responses

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -111,7 +111,7 @@ function RequestTimeoutError(ms) {
 }
 util.inherits(RequestTimeoutError, Error);
 
-function rawRequest(opts, cb) {
+function rawRequest(opts, retryInfo, cb) {
     assert.object(opts, 'options');
     assert.object(opts.log, 'options.log');
     assert.func(cb, 'callback');
@@ -222,6 +222,9 @@ function rawRequest(opts, cb) {
         emitResult((err || null), req, res);
     });
     req.log = log;
+    req.attempts = function getAttempts() {
+        return retryInfo.attempts;
+    };
 
     req.on('error', function onError(err) {
         dtrace._rstfy_probes['client-error'].fire(function () {
@@ -408,6 +411,8 @@ function HttpClient(options) {
     assert.optionalBool(options.followRedirects, 'options.followRedirects');
     assert.optionalString(options.noProxy, 'options.noProxy');
     assert.optionalNumber(options.maxRedirects, 'options.maxRedirects');
+    assert.optionalBool(options.exponentialBackoff,
+        'options.exponentialBackoff');
 
     EventEmitter.call(this);
 
@@ -440,6 +445,8 @@ function HttpClient(options) {
     }
 
     this.retry = cloneRetryOptions(options.retry);
+    this.exponentialBackoff =
+        (options.exponentialBackoff === false) ? false : true;
     this.signRequest = options.signRequest || false;
     this.socketPath = options.socketPath || false;
 
@@ -677,28 +684,54 @@ HttpClient.prototype.request = function request(opts, cb) {
     opts.audit = this.audit;
 
     if (opts.retry === false) {
-        rawRequest(opts, cb);
+        rawRequest(opts, {}, cb);
         return;
     }
 
     var call;
     var retry = cloneRetryOptions(opts.retry);
-
+    var retryInfo = {
+        retries: [],
+        // attempts start at 1, and will increment on per retry
+        attempts: 1
+    };
+    // set keep alive only when retries are enabled
     opts._keep_alive = this._keep_alive;
-    call = backoff.call(rawRequest, opts, cb);
-    call.setStrategy(new backoff.ExponentialStrategy({
-        initialDelay: retry.minTimeout,
-        maxDelay: retry.maxTimeout
-    }));
-    call.failAfter(retry.retries);
-    call.on('backoff', this.emit.bind(this, 'attempt'));
 
-    call.start();
+    if (opts.exponentialBackoff === false) {
+        // if no backoff, we have to keep track of num retries ourselves instead
+        // of relying on backoff module.
+        rawRequest(opts, retryInfo, function retryRawRequest(err, req) {
+            if (err && retryInfo.attempts <= retry.retries) {
+                retryInfo.attempts++;
+                return rawRequest(opts, retryInfo, retryRawRequest);
+            }
+            return cb(err, req);
+        });
+    } else {
+        // if backoff is specified (default behavior) then use backoff module
+        // to keep track of retry count.
+        call = backoff.call(rawRequest, opts, retryInfo, cb);
+        call.setStrategy(new backoff.ExponentialStrategy({
+            initialDelay: retry.minTimeout,
+            maxDelay: retry.maxTimeout
+        }));
+        call.failAfter(retry.retries);
+        // TODO: is this emitted event actually useful? if you have multiple
+        // inflight requests, how do you differentiate them?
+        call.on('backoff', this.emit.bind(this, 'attempt'));
+        call.on('backoff', function () {
+            // since a new req is created for each retry, we can't store retry
+            // info on the req. instead, store it on this retryInfo object
+            // created in this closure.
+            retryInfo.attempts++;
+        });
+        call.start();
+    }
 };
 
 
 HttpClient.prototype._options = function (method, options) {
-
     var self = this;
     var opts = {
         agent: (typeof options.agent !== 'undefined') ?
@@ -708,6 +741,8 @@ HttpClient.prototype._options = function (method, options) {
         cert: options.cert || self.cert,
         ciphers: options.ciphers || self.ciphers,
         connectTimeout: options.connectTimeout || self.connectTimeout,
+        exponentialBackoff: typeof options.exponentialBackoff !== 'undefined' ?
+            options.exponentialBackoff : self.exponentialBackoff,
         requestTimeout: options.requestTimeout || self.requestTimeout,
         headers: options.headers || {},
         key: options.key || self.key,
@@ -781,6 +816,7 @@ HttpClient.prototype._options = function (method, options) {
             delete opts.headers['transfer-encoding'];
         }
     }
+
 
     return (opts);
 };

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -222,7 +222,7 @@ function rawRequest(opts, retryInfo, cb) {
         emitResult((err || null), req, res);
     });
     req.log = log;
-    req.attempts = function getAttempts() {
+    req.getAttempts = function getAttempts() {
         return retryInfo.attempts;
     };
 
@@ -681,14 +681,13 @@ HttpClient.prototype.request = function request(opts, cb) {
     cb = once(cb);
     /* eslint-enable no-param-reassign */
 
-    opts.audit = this.audit;
+    var self = this;
+    opts.audit = self.audit;
 
     if (opts.retry === false) {
-        rawRequest(opts, {}, cb);
-        return;
+        return rawRequest(opts, {}, cb);
     }
 
-    var call;
     var retry = cloneRetryOptions(opts.retry);
     var retryInfo = {
         retries: [],
@@ -696,38 +695,38 @@ HttpClient.prototype.request = function request(opts, cb) {
         attempts: 1
     };
     // set keep alive only when retries are enabled
-    opts._keep_alive = this._keep_alive;
+    opts._keep_alive = self._keep_alive;
 
     if (opts.exponentialBackoff === false) {
         // if no backoff, we have to keep track of num retries ourselves instead
         // of relying on backoff module.
-        rawRequest(opts, retryInfo, function retryRawRequest(err, req) {
+        return rawRequest(opts, retryInfo, function retryRawRequest(err, req) {
             if (err && retryInfo.attempts <= retry.retries) {
                 retryInfo.attempts++;
                 return rawRequest(opts, retryInfo, retryRawRequest);
             }
             return cb(err, req);
         });
-    } else {
-        // if backoff is specified (default behavior) then use backoff module
-        // to keep track of retry count.
-        call = backoff.call(rawRequest, opts, retryInfo, cb);
-        call.setStrategy(new backoff.ExponentialStrategy({
-            initialDelay: retry.minTimeout,
-            maxDelay: retry.maxTimeout
-        }));
-        call.failAfter(retry.retries);
+    }
+
+    // if backoff is specified (default behavior) then use backoff module
+    // to keep track of retry count.
+    var call = backoff.call(rawRequest, opts, retryInfo, cb);
+    call.setStrategy(new backoff.ExponentialStrategy({
+        initialDelay: retry.minTimeout,
+        maxDelay: retry.maxTimeout
+    }));
+    call.failAfter(retry.retries);
+    call.on('backoff', function () {
+        // since a new req is created for each retry, we can't store retry
+        // info on the req. instead, store it on this retryInfo object
+        // created in this closure.
+        retryInfo.attempts++;
         // TODO: is this emitted event actually useful? if you have multiple
         // inflight requests, how do you differentiate them?
-        call.on('backoff', this.emit.bind(this, 'attempt'));
-        call.on('backoff', function () {
-            // since a new req is created for each retry, we can't store retry
-            // info on the req. instead, store it on this retryInfo object
-            // created in this closure.
-            retryInfo.attempts++;
-        });
-        call.start();
-    }
+        self.emit('attempt');
+    });
+    return call.start();
 };
 
 

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -689,6 +689,9 @@ HttpClient.prototype.request = function request(opts, cb) {
     }
 
     var retry = cloneRetryOptions(opts.retry);
+    // since a new req is created for each retry, we can't store retry
+    // info on the req. instead, store it on this retryInfo object
+    // created in this closure.
     var retryInfo = {
         retries: [],
         // attempts start at 1, and will increment on per retry
@@ -702,9 +705,9 @@ HttpClient.prototype.request = function request(opts, cb) {
         // of relying on backoff module.
         return rawRequest(opts, retryInfo, function retryRawRequest(err, req) {
             if (err && retryInfo.attempts <= retry.retries) {
-                self.emit('retry');
-                retryInfo.attempts++;
-                return rawRequest(opts, retryInfo, retryRawRequest);
+                return self._onRetry(err, retryInfo, function onRetryDone() {
+                    return rawRequest(opts, retryInfo, retryRawRequest);
+                });
             }
             return cb(err, req);
         });
@@ -712,20 +715,33 @@ HttpClient.prototype.request = function request(opts, cb) {
 
     // if backoff is specified (default behavior) then use backoff module
     // to keep track of retry count.
-    var call = backoff.call(rawRequest, opts, retryInfo, cb);
+    var call = backoff.call(function wrapRawRequest(backoffCb) {
+        // wrap the request retry so that we can emit a blocking 'retry' event.
+        return rawRequest(opts, retryInfo, function retryRawRequest(err, req) {
+            // check to see if we have exceeded retries - if yes, don't
+            // execute onRetry hook
+            if (err && retryInfo.attempts <= retry.retries) {
+                return self._onRetry(err, retryInfo, function onRetryDone() {
+                    return backoffCb(err, req);
+                });
+            }
+            return backoffCb(err, req);
+        });
+    }, cb);
     call.setStrategy(new backoff.ExponentialStrategy({
         initialDelay: retry.minTimeout,
         maxDelay: retry.maxTimeout
     }));
     call.failAfter(retry.retries);
-    call.on('backoff', function () {
-        // since a new req is created for each retry, we can't store retry
-        // info on the req. instead, store it on this retryInfo object
-        // created in this closure.
-        retryInfo.attempts++;
-        self.emit('retry');
-    });
     return call.start();
+};
+
+
+HttpClient.prototype._onRetry = function _onRetry(err, retryInfo, callback) {
+    var self = this;
+    retryInfo.attempts++;
+    self.emit('retry', err, retryInfo);
+    return callback();
 };
 
 

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -702,6 +702,7 @@ HttpClient.prototype.request = function request(opts, cb) {
         // of relying on backoff module.
         return rawRequest(opts, retryInfo, function retryRawRequest(err, req) {
             if (err && retryInfo.attempts <= retry.retries) {
+                self.emit('retry');
                 retryInfo.attempts++;
                 return rawRequest(opts, retryInfo, retryRawRequest);
             }
@@ -722,9 +723,7 @@ HttpClient.prototype.request = function request(opts, cb) {
         // info on the req. instead, store it on this retryInfo object
         // created in this closure.
         retryInfo.attempts++;
-        // TODO: is this emitted event actually useful? if you have multiple
-        // inflight requests, how do you differentiate them?
-        self.emit('attempt');
+        self.emit('retry');
     });
     return call.start();
 };

--- a/test/retries.js
+++ b/test/retries.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// external files
+var assert = require('chai').assert;
+var bunyan = require('bunyan');
+var restify = require('restify');
+
+// local files
+var clients = require('../lib');
+
+
+describe('backoffs and retries', function () {
+
+    var SERVER;
+    var LOG = bunyan.createLogger({
+        name: 'clientlog'
+    });
+    var CLIENT = clients.createJSONClient({
+        url: 'http://localhost:1000',
+        log: LOG
+    });
+
+    before(function (done) {
+        SERVER = restify.createServer({
+            name: 'unittest',
+            log: LOG
+        });
+        SERVER.listen(3000, done);
+    });
+
+
+    after(function (done) {
+        SERVER.close(done);
+    });
+
+    it('should exponentially backoff and retry 4 times', function (done) {
+        var start = Date.now();
+
+        CLIENT.get({
+            path: '/shouldfail',
+            retry: {
+                // set lower minTimeout so test doesn't take so long
+                minTimeout: 100
+            }
+        }, function (err, req, res, data) {
+            var elapsed = Date.now() - start;
+            assert.ok(err);
+            assert.include(err.message, 'ECONNREFUSED');
+            assert.strictEqual(req.attempts(), 5);
+            // in exponential back off, expect retries at:
+            // 100, 200, 400, 800 ~= 1500 ms total
+            assert.isAtLeast(elapsed, 1500);
+            return done();
+        });
+    });
+
+    it('should not exponentially backoff and retry 4 times', function (done) {
+        var start = Date.now();
+
+        CLIENT.get({
+            path: '/shouldfail',
+            exponentialBackoff: false
+        }, function (err, req, res, data) {
+            var elapsed = Date.now() - start;
+            assert.ok(err);
+            assert.include(err.message, 'ECONNREFUSED');
+            assert.strictEqual(req.attempts(), 5);
+            // this should be pretty instantaneous, usually 10ms but set 100
+            // for tests being run on travis or otherwise
+            assert.isBelow(elapsed, 100);
+            return done();
+        });
+    });
+});

--- a/test/retries.js
+++ b/test/retries.js
@@ -77,6 +77,43 @@ describe('backoffs and retries', function () {
         });
     });
 
+    it('should emit `retry` event on exponential retry', function (done) {
+        var retries = 0;
+
+        BAD_CLIENT.on('retry', function () {
+            retries++;
+        });
+
+        BAD_CLIENT.get({
+            path: '/shouldfail',
+            retry: {
+                // set lower minTimeout so test doesn't take so long
+                minTimeout: 100
+            }
+        }, function (err, req, res, data) {
+            assert.ok(err);
+            assert.strictEqual(retries, 4);
+            return done();
+        });
+    });
+
+    it('should emit `retry` event on non-exponential retry', function (done) {
+        var retries = 0;
+
+        BAD_CLIENT.on('retry', function () {
+            retries++;
+        });
+
+        BAD_CLIENT.get({
+            path: '/shouldfail',
+            exponentialBackoff: false
+        }, function (err, req, res, data) {
+            assert.ok(err);
+            assert.strictEqual(retries, 4);
+            return done();
+        });
+    });
+
     it('should not retry on 4xx', function (done) {
         SERVER.get('/4xx', function (req, res, next) {
             res.send(400);


### PR DESCRIPTION
By default, restify clients retries up to 4 times on failure to establish connection. This PR adds:

* an options flag `exponentialBackoff: false` which can be set on the client or on per request basis. this enables immediate retries without any backoff. 
* a `req.attempts()` method which returns the number of attempts made for this specific request