### PR TITLE
Breaking: throw on missing protocol in url options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## not yet released
 
 ### Breaking ###
+* #141: Throw when the `url` option does not have a valid http/https protocol.
 * #148: JSONClient is now strict about valid responses. Non JSON responses
   return parse errors to the caller. HTTP errors supersede parse errors. JSONP
   is also no longer supported. Empty responses return an empty pojo `{}`.

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -449,11 +449,10 @@ function HttpClient(options) {
             parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:',
             'must specify http/https protocol!'
         );
-        this.url = options.url;
+        this.url = parsedUrl;
     } else {
         this.url = {};
     }
-    this.url = options.url ? url.parse(options.url) : {};
 
     // HTTP proxy: `options.proxy` wins, else `https_proxy`/`http_proxy` envvars
     // (upper and lowercase) are used.

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -442,6 +442,17 @@ function HttpClient(options) {
     this.retry = cloneRetryOptions(options.retry);
     this.signRequest = options.signRequest || false;
     this.socketPath = options.socketPath || false;
+
+    if (options.url) {
+        var parsedUrl = url.parse(options.url);
+        assert.ok(
+            parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:',
+            'must specify http/https protocol!'
+        );
+        this.url = options.url;
+    } else {
+        this.url = {};
+    }
     this.url = options.url ? url.parse(options.url) : {};
 
     // HTTP proxy: `options.proxy` wins, else `https_proxy`/`http_proxy` envvars

--- a/test/HttpClient.test.js
+++ b/test/HttpClient.test.js
@@ -26,12 +26,14 @@ describe('HttpClient', function () {
             CLIENT = clients.createHttpClient({
                 url: 'http://www.restify.com'
             });
-            assert.strictEqual(CLIENT.url.protocol, 'http:');
+        });
+        assert.strictEqual(CLIENT.url.protocol, 'http:');
 
+        assert.doesNotThrow(function () {
             CLIENT = clients.createHttpClient({
                 url: 'https://www.restify.com'
             });
-            assert.strictEqual(CLIENT.url.protocol, 'https:');
         });
+        assert.strictEqual(CLIENT.url.protocol, 'https:');
     });
 });

--- a/test/HttpClient.test.js
+++ b/test/HttpClient.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// external files
+var assert = require('chai').assert;
+
+// local files
+var clients = require('../lib');
+
+
+describe('HttpClient', function () {
+
+    var CLIENT;
+
+
+    it('should throw on url without protocol', function () {
+        assert.throws(function () {
+            clients.createHttpClient({
+                url: 'localhost:3000'
+            });
+        }, 'must specify http/https protocol!');
+    });
+
+
+    it('should not throw on url with protocol', function () {
+        assert.doesNotThrow(function () {
+            CLIENT = clients.createHttpClient({
+                url: 'http://www.restify.com'
+            });
+            assert.strictEqual(CLIENT.url.protocol, 'http:');
+
+            CLIENT = clients.createHttpClient({
+                url: 'https://www.restify.com'
+            });
+            assert.strictEqual(CLIENT.url.protocol, 'https:');
+        });
+    });
+});


### PR DESCRIPTION
Fixes #141 

The behavior of `url.parse` is kind of mind blowing, too.