### PR TITLE
new: 'query' option in client constructor and per request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ var client = restify.createJsonClient({
   url: 'https://api.us-east-1.joyent.com',
   version: '*'
 });
-```    
+```
 
 ### API Options:
 
@@ -147,6 +147,7 @@ var client = restify.createJsonClient({
 |gzip|Object|Will compress data when sent using `content-encoding: gzip`|
 |headers|Object|HTTP headers to set in all requests|
 |log|Object|[bunyan](https://github.com/trentm/node-bunyan) instance|
+|query|Object|querystring object to be serialized via querystring module|
 |retry|Object|options to provide to node-retry;"false" disables retry; defaults to 4 retries|
 |safeStringify|Boolean|Safely serialize JSON objects, i.e. circular dependencies|
 |signRequest|Function|synchronous callback for interposing headers before request is sent|

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -726,6 +726,7 @@ HttpClient.prototype._options = function (method, options) {
                 options :
                 (options.path || self.path),
         pfx: options.pfx || self.pfx,
+        query: options.query || self.query,
         rejectUnauthorized: options.rejectUnauthorized ||
             self.rejectUnauthorized,
         retry: options.retry !== false ? options.retry : false,
@@ -736,12 +737,11 @@ HttpClient.prototype._options = function (method, options) {
         opts.retry = self.retry;
     }
 
-
-    // Backwards compatibility with restify < 1.0
-    if (options.query &&
-        Object.keys(options.query).length &&
+    // convert query option into querystring
+    if (opts.query &&
+        Object.keys(opts.query).length &&
         opts.path.indexOf('?') === -1) {
-        opts.path += '?' + querystring.stringify(options.query);
+        opts.path += '?' + querystring.stringify(opts.query);
     }
 
     if (this.socketPath) {

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -407,6 +407,7 @@ function HttpClient(options) {
     assert.object(options, 'options');
     assert.optionalObject(options.headers, 'options.headers');
     assert.object(options.log, 'options.log');
+    assert.optionalObject(options.query, 'options.query');
     assert.optionalFunc(options.signRequest, 'options.signRequest');
     assert.optionalString(options.socketPath, 'options.socketPath');
     assert.optionalString(options.url, 'options.url');
@@ -437,6 +438,7 @@ function HttpClient(options) {
     this.name = options.name || 'HttpClient';
     this.passphrase = options.passphrase;
     this.pfx = options.pfx;
+    this.query = options.query;
 
     if (typeof options.rejectUnauthorized !== 'undefined') {
         this.rejectUnauthorized = options.rejectUnauthorized;

--- a/test/JsonClient.test.js
+++ b/test/JsonClient.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// external files
+var assert = require('chai').assert;
+var bunyan = require('bunyan');
+var restify = require('restify');
+
+// local files
+var clients = require('../lib');
+
+
+describe('JsonClient', function () {
+
+    var SERVER;
+    var LOG = bunyan.createLogger({
+        name: 'clientlog'
+    });
+    var CLIENT = clients.createJsonClient({
+        url: 'http://localhost:3000',
+        log: LOG,
+        retry: false
+    });
+
+    beforeEach(function (done) {
+        SERVER = restify.createServer({
+            name: 'unittest',
+            log: LOG
+        });
+        SERVER.use(restify.plugins.queryParser());
+        SERVER.listen(3000, done);
+    });
+
+    afterEach(function (done) {
+        CLIENT.close();
+        SERVER.close(done);
+    });
+
+
+    it('should support query option for querystring', function (done) {
+        SERVER.get('/foo', function (req, res, next) {
+            assert.deepEqual(req.query, {
+                foo: 'bar'
+            });
+            res.send(200);
+            return next();
+        });
+
+        CLIENT.get({
+            path: '/foo',
+            query: {
+                foo: 'bar'
+            }
+        }, function (err, req, res, data) {
+            assert.ifError(err);
+            assert.strictEqual(req.path, '/foo?foo=bar');
+            return done();
+        });
+    });
+});

--- a/test/StringClient.test.js
+++ b/test/StringClient.test.js
@@ -30,6 +30,7 @@ describe('StringClient', function () {
             name: 'unittest',
             log: LOG
         });
+        SERVER.use(restify.plugins.queryParser());
         SERVER.listen(3000, done);
     });
 
@@ -90,6 +91,28 @@ describe('StringClient', function () {
                 assert.strictEqual(err2.name, 'RequestTimeoutError');
                 return done();
             });
+        });
+    });
+
+
+    it('should support query option for querystring', function (done) {
+        SERVER.get('/foo', function (req, res, next) {
+            assert.deepEqual(req.query, {
+                foo: 'bar'
+            });
+            res.send(200);
+            return next();
+        });
+
+        CLIENT.get({
+            path: '/foo',
+            query: {
+                foo: 'bar'
+            }
+        }, function (err, req, res, data) {
+            assert.ifError(err);
+            assert.strictEqual(req.path, '/foo?foo=bar');
+            return done();
         });
     });
 });


### PR DESCRIPTION
Went to try and fix #134 but could not repro. But added unit tests to make sure this is first class and supported moving fwd.