### PR TITLE
fix: handle request timeouts when a response object has not yet been created

### DIFF
--- a/lib/JsonClient.js
+++ b/lib/JsonClient.js
@@ -74,7 +74,7 @@ JsonClient.prototype.parse = function parse(req, callback) {
             parseErr = e;
             log.trace(parseErr, 'Invalid JSON in response');
         }
-        obj = obj || res.body || {};
+        obj = obj || (res && res.body) || {};
 
         // http errors take precedence over JSON.parse errors
         if (res && res.statusCode >= 400) {


### PR DESCRIPTION
Fixes #160.

Not sure how to best test this, any ideas? My guess is that connection establishment takes too long and the timeout triggers during this phase. 