### PR TITLE
dtrace-provider dependency inadvertently removed by #101

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "tunnel-agent": "^0.6.0",
     "uuid": "^3.0.1"
   },
-  "optionalDependency": {
+  "optionalDependencies": {
     "dtrace-provider": "^0.8.3"
   }
 }


### PR DESCRIPTION
This fixes issue #168. Would it be possible to also get a 1.5.3 release with this change? It looks like 1.5.2 came from bbdeb79442a0b79bf55a788b0a409a0b5dc9cc84, so a `1.x` branch could be made based on that.