### PR TITLE
fix(HttpClient): turn res stream to readable in HttpClient

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -188,8 +188,6 @@ function rawRequest(opts, cb) {
 
     var requestTime = new Date().getTime();
     req = proto.request(opts, function onResponse(res) {
-        res.resume();
-
         var latency = Date.now() - requestTime;
         res.headers['x-request-received'] = requestTime;
         res.headers['x-request-processing-time'] = latency;
@@ -211,10 +209,6 @@ function rawRequest(opts, cb) {
 
         req.removeAllListeners('socket');
 
-        res.once('readable', function onReadable () {
-            eventTimes.firstByteAt = process.hrtime();
-        });
-
         // End event is not emitted when stream is not consumed fully
         // in our case we consume it see: res.on('data')
         res.once('end', function onEnd () {
@@ -225,6 +219,11 @@ function rawRequest(opts, cb) {
         });
 
         emitResult((err || null), req, res);
+
+        // This has to be after res.on('data') in Node >= v10
+        res.once('readable', function onReadable () {
+            eventTimes.firstByteAt = process.hrtime();
+        });
     });
     req.log = log;
 

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -188,6 +188,8 @@ function rawRequest(opts, cb) {
 
     var requestTime = new Date().getTime();
     req = proto.request(opts, function onResponse(res) {
+        res.resume();
+
         var latency = Date.now() - requestTime;
         res.headers['x-request-received'] = requestTime;
         res.headers['x-request-processing-time'] = latency;

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -220,7 +220,10 @@ function rawRequest(opts, cb) {
 
         emitResult((err || null), req, res);
 
-        // This has to be after res.on('data') in Node >= v10
+        // This has to be after res.on('data') in Node >= v10:
+        // Adding a 'readable' listener stay in non-flowing mode even after
+        // a 'data' event listener is added to the same stream:
+        // https://github.com/nodejs/node/commit/cf5f9867ff3e700dfd72519e7bdeb701e254317f
         res.once('readable', function onReadable () {
             eventTimes.firstByteAt = process.hrtime();
         });

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -223,7 +223,8 @@ function rawRequest(opts, cb) {
         // This has to be after res.on('data') in Node >= v10:
         // Adding a 'readable' listener stay in non-flowing mode even after
         // a 'data' event listener is added to the same stream:
-        // https://github.com/nodejs/node/commit/cf5f9867ff3e700dfd72519e7bdeb701e254317f
+        // https://github.com/nodejs/node/commit/
+        // cf5f9867ff3e700dfd72519e7bdeb701e254317f
         res.once('readable', function onReadable () {
             eventTimes.firstByteAt = process.hrtime();
         });

--- a/test/StringClient.test.js
+++ b/test/StringClient.test.js
@@ -39,6 +39,22 @@ describe('StringClient', function () {
         SERVER.close(done);
     });
 
+    it('should make a request',
+    function (done) {
+        SERVER.get('/ping', function (req, res, next) {
+            res.send('pong');
+            return next();
+        });
+
+        CLIENT.get({
+            path: '/ping'
+        }, function (err, req, res, data) {
+            assert.ifError(err);
+            assert.equal(data, 'pong');
+            return done();
+        });
+    });
+
     it('should support decoding gzipped utf8 multibyte responses',
     function (done) {
         var payload = fs.readFileSync(path.join(


### PR DESCRIPTION
Turn res stream readable immediately to make it possible to consume later in inherited clients.