### PR TITLE
chore: rev dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ MOCHA		:= $(NODE_BIN)/mocha
 _MOCHA		:= $(NODE_BIN)/_mocha
 ISTANBUL	:= $(NODE_BIN)/istanbul
 COVERALLS	:= $(NODE_BIN)/coveralls
-NSP		:= $(NODE_BIN)/nsp
 JSON		:= $(NODE_BIN)/json
 
 
@@ -91,11 +90,6 @@ codestyle: $(NODE_MODULES) ## Run style checks
 .PHONY: codestyle-fix
 codestyle-fix: $(NODE_MODULES) ## Run and fix style check errors
 	@$(JSCS) $(ALL_FILES) --fix
-
-
-.PHONY: nsp
-nsp: $(NODE_MODULES) $(YARN_LOCK) ## Check for dependency vulnerabilities
-	@$(NSP) check --preprocessor yarn
 
 
 .PHONY: prepush

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "chai": "^4.0.2",
     "coveralls": "^3.0.2",
-    "eslint": "^5.1.0",
+    "eslint": "^4.19.1",
     "istanbul": "^0.4.0",
     "jscs": "^3.0.7",
     "json": "^9.0.4",

--- a/package.json
+++ b/package.json
@@ -46,18 +46,17 @@
   },
   "devDependencies": {
     "chai": "^4.0.2",
-    "coveralls": "^2.11.4",
-    "eslint": "^4.1.1",
+    "coveralls": "^3.0.2",
+    "eslint": "^5.1.0",
     "istanbul": "^0.4.0",
-    "jscs": "^2.11.0",
+    "jscs": "^3.0.7",
     "json": "^9.0.4",
     "mkdirp": "^0.5.1",
-    "mocha": "^3.4.2",
+    "mocha": "^5.2.0",
     "nock": "^9.0.13",
-    "nsp": "^2.0.1",
-    "proxyquire": "^1.8.0",
+    "proxyquire": "^2.0.1",
     "restify": "^4.3.0",
-    "sinon": "^4.1.2"
+    "sinon": "^6.1.3"
   },
   "dependencies": {
     "assert-plus": "^1.0.0",
@@ -65,7 +64,7 @@
     "bunyan": "^1.8.3",
     "fast-safe-stringify": "^2.0.3",
     "keep-alive-agent": "0.0.1",
-    "lodash": "^4.7.0",
+    "lodash": "^4.17.10",
     "lru-cache": "^4.0.1",
     "mime": "^2.2.0",
     "once": "^1.3.2",


### PR DESCRIPTION
Got tired of seeing the red outdated badge on the README. :)

EDIT: bummer, it seems eslint@5.x is only supported by node6+. Reverting back to eslint@4.x for now. 