### PR TITLE
breaking: support parsing of valid falsy json

### DIFF
--- a/lib/JsonClient.js
+++ b/lib/JsonClient.js
@@ -90,7 +90,12 @@ JsonClient.prototype.parse = function parse(err, req, res, callback) {
             parseErr = e;
             log.trace(parseErr, 'Invalid JSON in response');
         }
-        obj = obj || (res && res.body) || {};
+
+        // empty string and undefined are not valid JSON, fall back on the
+        // original response body (string) or empty POJO in worst case.
+        if (obj === '' || typeof obj === 'undefined') {
+            obj = (res && res.body) || {};
+        }
 
         // http errors take precedence over JSON.parse errors
         if (res && res.statusCode >= 400) {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "nock": "^9.0.13",
     "nsp": "^2.0.1",
     "proxyquire": "^1.8.0",
-    "restify": "^4.3.0",
+    "restify": "^7.2.1",
     "sinon": "^4.1.2"
   },
   "dependencies": {


### PR DESCRIPTION
As part of revving dependencies, I discovered a regression in JSONClient. I'm not sure when it happened, it looks like the tests were not even checking for the right thing. 

Essentially, if the server sends 0, null, or false, that is valid JSON and the client should respect it. This is similar to restify/node-restify#1609.