### PR TITLE
fix: callback getting invoked more than once causing throw 

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -89,6 +89,60 @@ function defaultUserAgent() {
 }
 
 
+/**
+ * A function that handles the issuing of the raw request through the
+ * underlying http core modules. This function is used as the target of
+ * retry/backoff mechanism for retrying on connection timeouts.
+ *
+ * The callback provided to this function is invoked with the following
+ * signature:
+ *      function(err, req) { ... }
+ * 1) `err` can only ever be a ConnectionTimeout. If this happens, req is
+ *    always null.
+ * 2) If no err, then the socket has been established, and the user must listen
+ *    to req's result event for further next steps.
+ *
+ * Following a successful socket establishment, the HttpClient emits a `result`
+ * event with the following signature:
+ *      function(err, res, req) { ... }   // yes, res is intentionally first
+ *
+ * Some notes:
+ *      * `err` can be a RequestTimeout or an http 4xx/5xx.
+ *      * res can be null in the case of RequestTimeout
+ *
+ * In the case of HttpClient, the callback provided to the function here is
+ * the user provided callback via the public API:
+ *      httpclient.get('/foo', cb);     // cb here is the rawRequest's cb
+ *
+ * This is intentional as the HttpClient is fairly low level. This means the
+ * user is responsible for consuming the request object's `data` and `result`
+ * events.
+ *
+ * In the case of the String/JSONClient, the cb is a function internal to those
+ * client implementations. These two clients handle dealing with the req
+ * streams, and do not invoke the user provided callback until after the
+ * `result` event is fired.
+ *
+ * In short, the callback should only ever be called once,
+ * with the two known scenarios:
+ *
+ * 1) A ConnectionTimeoutError occurs, and a the request object is never created
+ * 2) The socket is established, and the request object is created and returned
+ *
+ * However, a RequestTimeout can occur after the socket is established - which
+ * means we should not invoke the callback again (since it's already been
+ * invoked), and instead pass this error via the result event.
+ *
+ * This somewhat asymmetrical way of dealing with request errors (sometimes via
+ * the callback, sometimes via the result event) means that `once` is used to
+ * paper over multiple invocations of the callback function provided to this
+ * function. This is not great, and maybe worth revisiting.
+ * @private
+ * @method rawRequest
+ * @param {Object} opts an options object
+ * @param {Function} cb user provided callback fn
+ * @returns {undefined}
+ */
 function rawRequest(opts, cb) {
     assert.object(opts, 'options');
     assert.object(opts.log, 'options.log');
@@ -96,7 +150,7 @@ function rawRequest(opts, cb) {
     assert.func(cb, 'callback');
 
     /* eslint-disable no-param-reassign */
-    cb = once.strict(cb);
+    cb = once(cb);
     /* eslint-enable no-param-reassign */
 
     var id = dtrace.nextId();
@@ -114,10 +168,6 @@ function rawRequest(opts, cb) {
     var connectionTimer;
     var requestTimer;
     var req;
-    // flag that captures whether or not user provided callback has been
-    // invoked yet. this is an alternative to using once() that is more
-    // explicit.
-    var cbCalled = false;
 
     // increment the number of currently inflight requests
     opts.client._incrementInflightRequests();
@@ -322,10 +372,7 @@ function rawRequest(opts, cb) {
         // 'result' event. check the cbCalled flag to ensure we don't double
         // call the callback. while this could be handled by once, this is more
         // explicit and easier to reason about.
-        if (cbCalled === false) {
-            cbCalled = true;
-            cb(realErr, req);
-        }
+        cb(realErr, req);
 
         process.nextTick(function () {
             emitResult(realErr, req, null);
@@ -368,7 +415,6 @@ function rawRequest(opts, cb) {
         if (_socket.writable && !_socket._connecting) {
             startRequestTimeout();
             clearTimeout(connectionTimer);
-            cbCalled = true;
             cb(null, req);
             return;
         }
@@ -407,7 +453,6 @@ function rawRequest(opts, cb) {
             // possible for the request to timeout at this point, but a
             // RequestTimeoutError would be triggered through the 'result' event
             // and not the callback.
-            cbCalled = true;
             cb(null, req);
         });
     });

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -127,8 +127,8 @@ function defaultUserAgent() {
  * In short, the callback should only ever be called once,
  * with the two known scenarios:
  *
- * 1) A ConnectionTimeout/DNSTimeoutError occurs, and connection is never established,
- *    and the request object is never created
+ * 1) A ConnectionTimeout/DNSTimeoutError occurs, and connection is never
+ *    established, and the request object is never created
  * 2) The connection is established, and the request object is created and
  *    returned
  *

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -368,6 +368,7 @@ function rawRequest(opts, cb) {
         if (_socket.writable && !_socket._connecting) {
             startRequestTimeout();
             clearTimeout(connectionTimer);
+            cbCalled = true;
             cb(null, req);
             return;
         }
@@ -406,8 +407,8 @@ function rawRequest(opts, cb) {
             // possible for the request to timeout at this point, but a
             // RequestTimeoutError would be triggered through the 'result' event
             // and not the callback.
-            cb(null, req);
             cbCalled = true;
+            cb(null, req);
         });
     });
 

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -413,36 +413,7 @@ function rawRequest(opts, cb) {
     req.once('socket', function onSocket(socket) {
         var _socket = socket;
 
-        if (opts.protocol === 'https:' && socket.socket) {
-            _socket = socket.socket;
-        }
-
-        if (_socket.writable && !_socket._connecting) {
-            startRequestTimeout();
-            clearTimeout(connectionTimer);
-            cb(null, req);
-            return;
-        }
-
-        // if the provided url to connect to is already an IP, preemptively set
-        // the remote address.
-        if (net.isIP(opts.hostname)) {
-            req.remoteAddress = opts.hostname;
-        }
-
-        // eslint-disable-next-line handle-callback-err
-        _socket.once('lookup', function onLookup(err, addr, family, host) {
-            eventTimes.dnsLookupAt = process.hrtime();
-            // if we had do DNS lookup to resolve hostname, update remote
-            // address now.
-            req.remoteAddress = addr;
-        });
-
-        _socket.once('secureConnect', function () {
-            eventTimes.tlsHandshakeAt = process.hrtime();
-        });
-
-        _socket.once('connect', function onConnect() {
+        function onConnect() {
             startRequestTimeout();
             clearTimeout(connectionTimer);
 
@@ -459,7 +430,42 @@ function rawRequest(opts, cb) {
             // RequestTimeoutError would be triggered through the 'result' event
             // and not the callback.
             cb(null, req);
+        }
+
+        if (opts.protocol === 'https:' && socket.socket) {
+            _socket = socket.socket;
+        }
+
+        // if the provided url to connect to is already an IP, preemptively set
+        // the remote address.
+        if (net.isIP(opts.hostname)) {
+            req.remoteAddress = opts.hostname;
+        }
+
+        // before we attach any events to the socket, look to see if the
+        // socket's `connect` event has already fired. if the _connecting flag
+        // is false, the connection was established before we were able to
+        // attach a listener to the event, so return the request. it appears
+        // that in this scenario, timers for dnsLookup and tlsHandshake would
+        // be missing.
+        if (_socket.writable && !_socket._connecting) {
+            onConnect();
+            return;
+        }
+
+        // eslint-disable-next-line handle-callback-err
+        _socket.once('lookup', function onLookup(err, addr, family, host) {
+            eventTimes.dnsLookupAt = process.hrtime();
+            // if we had do DNS lookup to resolve hostname, update remote
+            // address now.
+            req.remoteAddress = addr;
         });
+
+        _socket.once('secureConnect', function () {
+            eventTimes.tlsHandshakeAt = process.hrtime();
+        });
+
+        _socket.once('connect', onConnect);
     });
 
     if (log.trace()) {

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -97,13 +97,14 @@ function defaultUserAgent() {
  * The callback provided to this function is invoked with the following
  * signature:
  *      function(err, req) { ... }
- * 1) `err` can only ever be a ConnectionTimeout. If this happens, req is
- *    always null.
- * 2) If no err, then the socket has been established, and the user must listen
- *    to req's result event for further next steps.
+ * 1) `err` can be any errors triggered before establishing a connection
+ *    (ConnectionTimeout, DNSTimeout, etc)
+ * 2) If no err, then the connection has been established, and the user must
+ *    listen to req's result event for further next steps.
  *
- * Following a successful socket establishment, the HttpClient emits a `result`
- * event with the following signature:
+ * Once the server begins to send a response following a successful connection
+ * establishment, the HttpClient emits a `result` event with the following
+ * signature:
  *      function(err, res, req) { ... }   // yes, res is intentionally first
  *
  * Some notes:
@@ -126,17 +127,21 @@ function defaultUserAgent() {
  * In short, the callback should only ever be called once,
  * with the two known scenarios:
  *
- * 1) A ConnectionTimeoutError occurs, and a the request object is never created
- * 2) The socket is established, and the request object is created and returned
+ * 1) A ConnectionTimeout/DNSTimeoutError occurs, and connection is never established,
+ *    and the request object is never created
+ * 2) The connection is established, and the request object is created and
+ *    returned
  *
- * However, a RequestTimeout can occur after the socket is established - which
- * means we should not invoke the callback again (since it's already been
- * invoked), and instead pass this error via the result event.
+ * However, a RequestTimeout can occur after the connection is established -
+ * which means we should not invoke the callback again (since it's already been
+ * invoked), and instead pass this error via the `result` event.
  *
  * This somewhat asymmetrical way of dealing with request errors (sometimes via
  * the callback, sometimes via the result event) means that `once` is used to
  * paper over multiple invocations of the callback function provided to this
- * function. This is not great, and maybe worth revisiting.
+ * function. This is not great, and maybe worth revisiting. The `result` event,
+ * like the callback, should only ever be emitted once.
+ *
  * @private
  * @method rawRequest
  * @param {Object} opts an options object

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -323,8 +323,8 @@ function rawRequest(opts, cb) {
         // call the callback. while this could be handled by once, this is more
         // explicit and easier to reason about.
         if (cbCalled === false) {
-            cb(realErr, req);
             cbCalled = true;
+            cb(realErr, req);
         }
 
         process.nextTick(function () {


### PR DESCRIPTION
I have observed that in scenarios where the process is under heavy CPU usage, that it's possible to hit the case where the callback is called multiple times due to how work is getting scheduled. This leads me to think that it would be safer to set the flag before invoking the user provided callback, but I'm not sure how to go about testing/verifying this.

Any thoughts? 