### PR TITLE
feat(qs): support serializing objects into associative array params

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -8,7 +8,7 @@ var http = require('http');
 var https = require('https');
 var net = require('net');
 var os = require('os');
-var querystring = require('querystring');
+var qs = require('qs');
 var url = require('url');
 var util = require('util');
 
@@ -957,7 +957,7 @@ HttpClient.prototype._options = function (method, options) {
     if (opts.query &&
         Object.keys(opts.query).length &&
         opts.path.indexOf('?') === -1) {
-        opts.path += '?' + querystring.stringify(opts.query);
+        opts.path += '?' + qs.stringify(opts.query);
     }
 
     if (this.socketPath) {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lru-cache": "^4.0.1",
     "mime": "^2.2.0",
     "once": "^1.4.0",
+    "qs": "^6.5.2",
     "restify-errors": "^6.0.0",
     "semver": "^5.0.1",
     "tunnel-agent": "^0.6.0",

--- a/test/querystring.test.js
+++ b/test/querystring.test.js
@@ -65,6 +65,31 @@ describe('query string parameters', function () {
             CLIENT.get('/foo', done);
         });
 
+        it('should support serializing objects into associative array',
+        function (done) {
+            SERVER.get('/foo', function (req, res, next) {
+                assert.deepEqual(req.query, {
+                    foo: {
+                        a: 'coffee',
+                        b: 'beans'
+                    }
+                });
+                res.send(200);
+                return next();
+            });
+
+            CLIENT = clients.createJsonClient({
+                url: 'http://localhost:3000/foo',
+                query: {
+                    foo: {
+                        a: 'coffee',
+                        b: 'beans'
+                    }
+                }
+            });
+            CLIENT.get('/foo', done);
+        });
+
         it('should prefer query option over query in url', function (done) {
             SERVER.get('/foo', function (req, res, next) {
                 assert.deepEqual(req.query, {
@@ -121,6 +146,33 @@ describe('query string parameters', function () {
             });
             CLIENT.get({
                 path: '/foo?foo=bar'
+            }, done);
+        });
+
+        it('should support serializing objects into associative array',
+        function (done) {
+            SERVER.get('/foo', function (req, res, next) {
+                assert.deepEqual(req.query, {
+                    foo: {
+                        a: 'coffee',
+                        b: 'beans'
+                    }
+                });
+                res.send(200);
+                return next();
+            });
+
+            CLIENT = clients.createJsonClient({
+                url: 'http://localhost:3000/foo'
+            });
+            CLIENT.get({
+                path: '/foo',
+                query: {
+                    foo: {
+                        a: 'coffee',
+                        b: 'beans'
+                    }
+                }
             }, done);
         });
 


### PR DESCRIPTION
Restify deserializes `?foo[a]=1&foo[b]=2` into a POJO - seems restify-clients should be symmetrical and do the same on the way out. 