### PR TITLE
fix: ensure getMetrics and getTimings are always available

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -370,6 +370,30 @@ function rawRequest(opts, cb) {
         clearTimeout(requestTimer);
         opts.client._decrementInflightRequests();
 
+        // in an error scenario, it's possible the connection died and we were
+        // never able to set timings/metrics methods on the req object.
+        if (!req.getTimings || !req.getMetrics) {
+            eventTimes.endAt = process.hrtime();
+            var timings = getTimingsFromEventTimes(eventTimes);
+            req.getTimings = function getTimings () {
+                return timings;
+            };
+            opts.client.emit('timings', timings);
+
+            var metrics = {
+                statusCode: NaN,
+                method: req.method,
+                path: opts.path,
+                url: opts.href,
+                success: (err) ? false : true
+            };
+            metrics.timings = timings;
+            req.getMetrics = function getMetrics() {
+                return metrics;
+            };
+            opts.client.emit('metrics', metrics);
+        }
+
         // the user provided callback is invoked as soon as a connection is
         // established. however, the request can be aborted or can fail after
         // this point. any errors that occur after connection establishment are

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -370,7 +370,8 @@ function rawRequest(opts, cb) {
         clearTimeout(requestTimer);
         opts.client._decrementInflightRequests();
 
-        // in an error scenario, it's possible the connection died and we were
+        // in an error scenario, it's possible the connection died and the
+        // response's `end` event never fired. if that's the case, we were
         // never able to set timings/metrics methods on the req object.
         if (!req.getTimings || !req.getMetrics) {
             eventTimes.endAt = process.hrtime();
@@ -381,7 +382,7 @@ function rawRequest(opts, cb) {
             opts.client.emit('timings', timings);
 
             var metrics = {
-                statusCode: NaN,
+                statusCode: null,
                 method: req.method,
                 path: opts.path,
                 url: opts.href,

--- a/test/index.js
+++ b/test/index.js
@@ -260,6 +260,10 @@ describe('restify-client tests', function () {
                 res.send(500);
                 return next();
             });
+            SERVER.get('/econnreset', function (req, res, next) {
+                req.socket.destroy();
+                return next();
+            });
 
             SERVER.listen(PORT, '127.0.0.1', function () {
                 PORT = SERVER.address().port;
@@ -552,6 +556,31 @@ describe('restify-client tests', function () {
                 assert.isNumber(metrics.timings.contentTransfer);
                 assert.isNumber(metrics.timings.total);
                 done();
+            });
+        });
+
+        it('should return best effort metrics and timings in error scenarios',
+        function (done) {
+            METRICS_CLIENT_HOST.get('/econnreset', function (err, req, res) {
+                assert.ok(err);
+                assert.strictEqual(err.code, 'ECONNRESET');
+            });
+
+            METRICS_CLIENT_HOST.once('metrics', function (metrics) {
+                assert.isObject(metrics);
+                assert.strictEqual(metrics.statusCode.toString(), 'NaN');
+                assert.strictEqual(metrics.method, 'GET');
+                assert.strictEqual(metrics.path, '/econnreset');
+                assert.include(metrics.url, 'http://localhost');
+                assert.strictEqual(metrics.success, false);
+                assert.isObject(metrics.timings);
+                assert.isNumber(metrics.timings.dnsLookup);
+                assert.isNull(metrics.timings.tlsHandshake);
+                assert.isNumber(metrics.timings.tcpConnection);
+                assert.isNull(metrics.timings.firstByte);
+                assert.isNull(metrics.timings.contentTransfer);
+                assert.isNumber(metrics.timings.total);
+                return done();
             });
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -568,7 +568,7 @@ describe('restify-client tests', function () {
 
             METRICS_CLIENT_HOST.once('metrics', function (metrics) {
                 assert.isObject(metrics);
-                assert.strictEqual(metrics.statusCode.toString(), 'NaN');
+                assert.strictEqual(metrics.statusCode, null);
                 assert.strictEqual(metrics.method, 'GET');
                 assert.strictEqual(metrics.path, '/econnreset');
                 assert.include(metrics.url, 'http://localhost');


### PR DESCRIPTION
Fixes #191 