### PR TITLE
Explore optional transform hook

### DIFF
--- a/lib/StringClient.js
+++ b/lib/StringClient.js
@@ -3,7 +3,9 @@
 'use strict';
 
 var crypto = require('crypto');
+var stream = require('stream');
 var zlib = require('zlib');
+
 var StringDecoder = require('string_decoder').StringDecoder;
 
 var assert = require('assert-plus');
@@ -39,9 +41,16 @@ function StringClient(options) {
     options.contentType =
         options.contentType || 'application/x-www-form-urlencoded';
 
+    // TODO: Remove
+    // Inserting a pass-through to demonstrate transform hook.
+    options.createTransform = function () {
+        return new stream.PassThrough();
+    };
+
     HttpClient.call(this, options);
     this.contentMd5 = options.contentMd5 || {};
     this.gzip = options.gzip;
+    this.createTransform = options.createTransform || function () {};
 
     if (!this.contentMd5.encodings) {
         // The undefined value here is used to make node use the default
@@ -226,6 +235,9 @@ StringClient.prototype.parse = function parse(err, req, res, callback) {
     var md5Match;
     var decoder;
 
+    var self = this;
+    var transform = self.createTransform();
+
     function done() {
         res.log.trace('body received:\n%s', body);
         res.body = body;
@@ -249,6 +261,15 @@ StringClient.prototype.parse = function parse(err, req, res, callback) {
         return callback(err, body);
     }
 
+    var shouldTransform = transform && typeof transform.write === 'function';
+
+    if (shouldTransform) {
+        transform.once('end', done);
+        transform.on('data', function (chunk) {
+            body += chunk;
+        });
+    }
+
     md5 = res.headers['content-md5'];
 
     if (md5 && req.method !== 'HEAD' && res.statusCode !== 206 &&
@@ -264,16 +285,28 @@ StringClient.prototype.parse = function parse(err, req, res, callback) {
         decoder = new StringDecoder('utf8');
         gz = zlib.createGunzip();
         gz.on('data', function (chunk) {
-            body += decoder.write(Buffer.from(chunk));
+            var decoded = decoder.write(Buffer.from(chunk));
+
+            if (transform) {
+                transform.write(decoded);
+            } else {
+                body += decoded;
+            }
         });
         gz.once('end', function () {
-            body += decoder.end();
-            done();
+            var rest = decoder.end();
+
+            if (shouldTransform) {
+                transform.end(rest);
+            } else {
+                body += rest;
+                done();
+            }
         });
         res.once('end', gz.end.bind(gz));
     } else {
         res.setEncoding('utf8');
-        res.once('end', done);
+        res.once('end', shouldTransform ? transform.end.bind(transform) : done);
     }
 
     res.on('data', function onData(chunk) {
@@ -286,7 +319,7 @@ StringClient.prototype.parse = function parse(err, req, res, callback) {
         if (gz) {
             gz.write(chunk);
         } else {
-            body += chunk;
+            shouldTransform ? transform.write(chunk) : body += chunk;
         }
     });
 };


### PR DESCRIPTION
# RFC

Large bodies, XML feeds for example, must be processed as streams. Here , I’m exploring a way to optionally allow hooking a transform stream into the string client. I chose `Transform` to give users control over accumulation. I offer this simple approach for discussion, don’t merge. 🧐