### PR TITLE
Updating lodash version to ^4.17.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-clients",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "main": "lib/index.js",
   "description": "HttpClient, StringClient, and JsonClient extracted from restify",
   "homepage": "http://www.restify.com",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "bunyan": "^1.8.12",
     "fast-safe-stringify": "^2.0.6",
     "keep-alive-agent": "0.0.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "lru-cache": "^5.1.1",
     "mime": "^2.4.0",
     "once": "^1.4.0",


### PR DESCRIPTION
lodash is having a high vulnerability in versions <=4.7.11, hence updating the lodash version