### PR TITLE
 fix: Allow following redirects that go to another server

### DIFF
--- a/lib/StringClient.js
+++ b/lib/StringClient.js
@@ -119,7 +119,11 @@ StringClient.prototype.read = function read(options, callback) {
         req.once('result', self._onResult(callback));
         req.once('redirect', function (res) {
             res.resume();
-            options.path = res.headers.location;
+            var redirectURL = new URL(res.headers.location);
+            options.protocol = redirectURL.protocol;
+            options.hostname = redirectURL.hostname;
+            options.port = redirectURL.port;
+            options.path = redirectURL.href;
 
             if (res.forceGet) {
                 forceGetOptions(options);


### PR DESCRIPTION
For issue #212 allowing for redirects that go to another server.

This may not be the best approach, as I'm still quite new to node, but this fix solves the use case that caused me to find the problem. There may be other stuff that should be kept as well, like usernames/passwords on the URL. You're the experts, please feel free to adopt, adapt, or ignore this change.