### PR TITLE
Ignore IncomingMessage errors after response

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -189,7 +189,7 @@ function rawRequest(opts, cb) {
      * @param {Object} [_res] response object
      * @return {undefined}
      */
-    var emitAfter = once.strict(function _emitAfter(_req, _res, _err) {
+    var emitAfter = once(function _emitAfter(_req, _res, _err) {
         assert.optionalObject(_err, '_err');
         assert.object(_req, '_req');
         assert.optionalObject(_res, '_res');
@@ -219,7 +219,7 @@ function rawRequest(opts, cb) {
      * @param {Object} [_res] response object
      * @return {undefined}
      */
-    var emitResult = once.strict(function _emitResult(_err, _req, _res) {
+    var emitResult = once(function _emitResult(_err, _req, _res) {
         assert.optionalObject(_err, '_err');
         assert.object(_req, '_req');
         assert.optionalObject(_res, '_res');
@@ -417,12 +417,19 @@ function rawRequest(opts, cb) {
         // established. however, the request can be aborted or can fail after
         // this point. any errors that occur after connection establishment are
         // not propagated via the callback, but instead propagated via the
-        // 'result' event. check the cbCalled flag to ensure we don't double
-        // call the callback. while this could be handled by once, this is more
-        // explicit and easier to reason about.
+        // 'result' event. In this scenario, cb's invocation here will no-op.
         cb(realErr, req);
 
         process.nextTick(function () {
+            // 'error' emitted after 'response' or 'end' on IncomingMessage is
+            // a known surprising to consumers scenario, and so is disregarded
+            // by wrapping both emitResult & emitAfter w/once() for 2 reasons:
+            // 1. The legacy implementation here did not propagate it.
+            // 2. In the future, core likely won't for the same reason:
+            //     https://github.com/nodejs/node/issues/27916
+            //     https://github.com/nodejs/node/pull/29197
+            //     https://github.com/nodejs/node/pull/20077
+            //     https://github.com/nodejs/node/pull/28683
             emitResult(realErr, req, null);
             emitAfter(req, null, realErr);
         });
@@ -897,7 +904,7 @@ HttpClient.prototype.request = function request(opts, cb) {
     assert.func(cb, 'callback');
 
     /* eslint-disable no-param-reassign */
-    cb = once.strict(cb);
+    cb = once(cb);
     /* eslint-enable no-param-reassign */
 
     opts.audit = this.audit;


### PR DESCRIPTION
Comments are fairly self explanatory. Happy to expand & discuss further.

TLDR; `HttpClient.request` is currently unavoidably throwing for a known non-actionable failure scenario in core, so we're now disregarding it.