### PR TITLE
chore(HttpClient): keep User-Agent on headers

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -721,9 +721,12 @@ function HttpClient(options) {
         this.headers['content-type'] = options.contentType;
     }
 
-    if (options.userAgent !== false) {
-        this.headers['user-agent'] = options.userAgent ||
-            defaultUserAgent();
+    if (options.userAgent) {
+        this.headers['user-agent'] = options.userAgent;
+    }
+
+    if (!this.headers['user-agent']) {
+        this.headers['user-agent'] = defaultUserAgent();
     }
 
     if (options.version) {

--- a/test/HttpClient.test.js
+++ b/test/HttpClient.test.js
@@ -45,4 +45,27 @@ describe('HttpClient', function () {
         assert.strictEqual(CLIENT.url.hostname, 'www.restify.com');
         assert.strictEqual(CLIENT.url.port, '3000');
     });
+
+    it('should fill default User Agent when none is given', function () {
+        CLIENT = clients.createHttpClient();
+        assert.strictEqual(CLIENT.headers['user-agent'].slice(0, 8),
+                           'restify/');
+    });
+
+    it('should keep User Agent from headers if none is given', function () {
+        const userAgent = 'The Acme Browser 0.42';
+        CLIENT = clients.createHttpClient({
+            headers: {'user-agent': userAgent}
+        });
+        assert.strictEqual(CLIENT.headers['user-agent'], userAgent);
+    });
+
+    it('should use given User Agent', function () {
+        const userAgent = 'The Acme Browser 0.42';
+        CLIENT = clients.createHttpClient({
+            headers: {'user-agent': 'Not The Acme Browser 0.00'},
+            userAgent
+        });
+        assert.strictEqual(CLIENT.headers['user-agent'], userAgent);
+    });
 });


### PR DESCRIPTION
BREAKING CHANGE: if User-Agent is given via headers, but is not given
via options, keep the headers User-Agent instead of replacing it with
restify-clients UA. This change makes User-Agent handling more aligned
with how restify-clients deals with other headers which can be overriten
by options.

The reasoning behind this is in cases where restify-clients is acting
like a forward-proxy of sorts. If User-Agent is present in headers
there's probably a request forwarding happening.