### PR TITLE
chore(package)!: use conventionalcommits preset

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,19 @@
+---
+name: Conventional Commit Linter
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  name: Lint
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js v12
+      uses: actions/setup-node@v1
+      with:
+        node-version: v12
+    - run: npm install
+    - run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}

--- a/Makefile
+++ b/Makefile
@@ -120,12 +120,12 @@ clean: ## Cleans unit test coverage files and node_modules.
 
 .PHONY: release-dry
 release-dry: $(NODE_MODULES) $(UNLEASH) ## Dry run of `release` target
-	@$(UNLEASH) -d --type=$(shell $(CONVENTIONAL_RECOMMENDED_BUMP) -p angular)
+	@$(UNLEASH) -d --type=$(shell $(CONVENTIONAL_RECOMMENDED_BUMP) -p conventionalcommits)
 
 
 .PHONY: release
 release: $(NODE_MODULES) $(UNLEASH) security ## Versions, tags, and updates changelog based on commit messages
-	@$(UNLEASH) --type=$(shell $(CONVENTIONAL_RECOMMENDED_BUMP) -p angular) --no-publish
+	@$(UNLEASH) --type=$(shell $(CONVENTIONAL_RECOMMENDED_BUMP) -p conventionalcommits) --no-publish
 	@$(NPM) publish
 
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules : {
+        'scope-case': [2, 'always', ['lower-case', 'pascal-case']]
+    }
+};

--- a/package.json
+++ b/package.json
@@ -45,9 +45,11 @@
     "test": "make test"
   },
   "devDependencies": {
+    "@commitlint/cli": "^9.0.1",
+    "@commitlint/config-conventional": "^9.0.1",
     "chai": "^4.2.0",
-    "conventional-changelog-angular": "^5.0.0",
-    "conventional-recommended-bump": "^4.0.0",
+    "conventional-changelog-conventionalcommits": "^4.3.0",
+    "conventional-recommended-bump": "^6.0.9",
     "coveralls": "^3.0.2",
     "eslint": "^4.19.1",
     "jscs": "^3.0.7",


### PR DESCRIPTION
Instead of using angular's preset, use conventionalcommits preset to
ensure we're following the Conventional Commits  standard.