### PR TITLE
feat: drop engine field on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,5 @@
   },
   "optionalDependencies": {
     "dtrace-provider": "^0.8.7"
-  },
-  "engines": {
-    "node": ">=10.0.0 <15.0.0"
   }
 }


### PR DESCRIPTION
`yarn` respects the engine field, which makes any changes to it a
breaking change to all dependencies of `restify-clients`. The `engine`
field was originally added in this project to be informative, not a
strict restriction. Drop it to prevent unwanted breaking changes on
other packages.